### PR TITLE
Add Prometheus Scrape

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 | [`mysql_client`](interfaces/mysql_client/v0/README.md)                       | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 | [`postgresql_client`](interfaces/postgresql_client/v0/README.md)             | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 | [`prometheus_remote_write`](interfaces/prometheus_remote_write/v0/README.md) | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+| [`prometheus_scrape`](interfaces/prometheus_scrape/v0/README.md)             | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 | [`tls_certificates/v0`](interfaces/tls_certificates/v0/README.md)            | ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen) |
 | [`tls_certificates/v1`](interfaces/tls_certificates/v1/README.md)            | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 

--- a/interfaces/prometheus_scrape/v0/README.md
+++ b/interfaces/prometheus_scrape/v0/README.md
@@ -1,0 +1,107 @@
+# `prometheus_scrape`
+
+## Usage
+
+This relation interface describes the expected behavior of any charm claiming to be able to provide or require Prometheus Scrape Endpoints.
+
+In most cases, this will be accomplished using the [prometheus_scrape library](https://charmhub.io/prometheus-k8s/libraries/prometheus_scrape), although charm developers are free to provide alternative libraries as long as they fulfill the behavioral and schematic requirements described in this document.
+
+## Direction
+
+```mermaid
+flowchart TD
+    Provider -- "Scrape Job(s), Alert Rules, Metadata" --> Requirer
+    Requirer -- Scrapes --> Provider
+```
+
+As all Juju relations, the `prometheus_scrape` interface consists of a provider and a requirer. One of these, in this case the `Provider`, will be expected to stand up one or more scrape compatible metrics endpoint where the `Requirer` will be able to scrape the `Provider`s metrics.
+
+## Behavior
+
+Both the Requirer and the provider need to adhere to a certain set of criterias to be considered compatible with the interface.
+
+### Provider
+
+- Is expected to provide one or more Prometheus scrape jobs in the relation data bag.
+- Is expected to respect the metrics topology set by the requirer.
+- Is expected to provide alert rules over the relation data bag.
+- Is expected to add any wanted topology labels to all metrics sent to the provider.
+- Is expected to provide any wanted topology label matchers as labels on every alert rule in the relation data bag.
+- Is expected to be able to expose both single alert rules and alert rule groups over the relation data bag.
+- Is expected to send alert rules where the contain expressions lacks Juju topology label selectors.
+
+### Requirer
+- Is expected to be able to scrape Prometheus metrics from a metrics endpoint
+- Is expected to be able to ingest alert rules exposed over the relation data bag.
+- Is expected to fetch the target configuration from the relation data bag.
+- Is expected to inject alert rule topology labels as label matchers in alert rule expressions.
+- Is expected not to inject juju_unit as a label matcher by default, but to honor it if hard-coded by the user.
+- Is expected to be able to ingest both single alert rules and alert rule groups provided over the relation data bag.
+
+## Relation Data
+
+### Provider
+
+[\[JSON Schema\]](./schemas/provider.json)
+
+- Exposes all scrape jobs the requirer should scrape metrics through. Should be placed in the **application** databag.
+- Exposes the unit address of each unit to scrape, as well as the unit name of each address. Should be placed in the **unit** databag of each scrapable unit.
+
+#### Example
+
+
+```yaml
+application-data:
+  alert_rules: {
+    "groups": [
+      {
+        "name": "an_alert_rule_group",
+        "rules": [
+          {
+            "alert": "SomethingIsUp",
+            "expr": "something_bad == 1",
+            "for": "0m",
+            "labels": {
+              "some-label": "some-value"
+            },
+            "annotations": {
+              "some-annotation": "some-other-value"
+            }
+          }
+        ]
+      }
+    ]
+  }
+  scrape_jobs: [
+    {
+      "metrics_path": "/metrics", 
+      "static_configs": [
+        { "targets": ["*:4080"] }
+      ]
+    }
+  ]
+  scrape_metadata: {
+    "model": "cos",
+    "model_uuid": "c2e9f4d5-dcb3-4870-8509-330eb9745ee8",
+    "application": "zinc-k8s",
+    "unit": "zinc-k8s/0",
+    "charm_name": "zinc-k8s"
+  }
+related-units:
+  zinc-k8s/0:
+    data:
+      prometheus_scrape_unit_address: zinc-k8s-0.zinc-k8s-endpoints.cos.svc.cluster.local
+      prometheus_scrape_unit_name: zinc-k8s/0
+      # ...
+    # ...
+  zinc-k8s/1:
+    data:
+      prometheus_scrape_unit_address: zinc-k8s-1.zinc-k8s-endpoints.cos.svc.cluster.local
+      prometheus_scrape_unit_name: zinc-k8s/1
+      # ...
+    # ...
+```
+
+### Requirer
+
+No relation data should be exposed by the requirer of this relation.

--- a/interfaces/prometheus_scrape/v0/charms.yaml
+++ b/interfaces/prometheus_scrape/v0/charms.yaml
@@ -1,0 +1,4 @@
+providers:
+  - prometheus-k8s
+consumers:
+  - grafana-agent-k8s

--- a/interfaces/prometheus_scrape/v0/schemas/provider.json
+++ b/interfaces/prometheus_scrape/v0/schemas/provider.json
@@ -1,0 +1,279 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/prometheus_scrape/schemas/provider.json",
+    "title": "`prometheus_scrape` provider root schema",
+    "type": "object",
+    "additionalProperties": true,
+    "examples": [
+        {
+            "application-data": {
+                "alert_rules": {
+                    "groups": [
+                        {
+                            "name": "an_alert_rule_group",
+                            "rules": [
+                                {
+                                    "alert": "SomethingIsUp",
+                                    "expr": "something_bad == 1",
+                                    "for": "0m",
+                                    "labels": {
+                                        "some-label": "some-value"
+                                    },
+                                    "annotations": {
+                                        "some-annotation": "some-other-value"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "scrape_jobs": [
+                    {
+                        "metrics_path": "/metrics",
+                        "static_configs": [
+                            {
+                                "targets": [
+                                    "*:4080"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "scrape_metadata": {
+                    "model": "cos",
+                    "model_uuid": "c2e9f4d5-dcb3-4870-8509-330eb9745ee8",
+                    "application": "zinc-k8s",
+                    "unit": "zinc-k8s/0",
+                    "charm_name": "zinc-k8s"
+                }
+            },
+            "related-units": {
+                "zinc-k8s/0": {
+                    "data": {
+                        "prometheus_scrape_unit_address": "zinc-k8s-0.zinc-k8s-endpoints.cos.svc.cluster.local",
+                        "prometheus_scrape_unit_name": "zinc-k8s/0"
+                    }
+                }
+            }
+        }
+    ],
+    "properties": {
+        "application-data": {
+            "$id": "#/properties/application-data",
+            "title": "Application Databag",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+                "alert_rules": {
+                    "$id": "#/properties/application-data/alert_rules",
+                    "title": "Alert rules exposed by the provider",
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                        "groups": {
+                            "$id": "#/properties/application-data/alert_rules/groups",
+                            "title": "Alert rule groups exposed by the provider",
+                            "type": "array",
+                            "additionalItems": true,
+                            "items": [
+                                {
+                                    "$id": "#/properties/application-data/alert_rules/groups/0",
+                                    "title": "Alert rule group exposed by the provider",
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "properties": {
+                                        "name": {
+                                            "$id": "#/properties/application-data/alert_rules/groups/0/name",
+                                            "title": "Name of an alert rule group",
+                                            "type": "string"
+                                        },
+                                        "rules": {
+                                            "$id": "#/properties/application-data/alert_rules/groups/0/rules",
+                                            "title": "List of rules in an alert rule group",
+                                            "type": "array",
+                                            "additionalItems": true,
+                                            "items": [
+                                                {
+                                                    "alert": {
+                                                        "$id": "#/properties/application-data/alert_rules/groups/0/rules/0/alert",
+                                                        "title": "Name of an individual alert rule",
+                                                        "type": "string"
+                                                    },
+                                                    "expr": {
+                                                        "$id": "#/properties/application-data/alert_rules/groups/0/rules/0/expr",
+                                                        "title": "PromQL or LogQL expression of an individual alert rule",
+                                                        "type": "string"
+                                                    },
+                                                    "for": {
+                                                        "$id": "#/properties/application-data/alert_rules/groups/0/rules/0/for",
+                                                        "title": "The duration for which an alert must triggered before it fires",
+                                                        "type": "string"
+                                                    },
+                                                    "labels": {
+                                                        "$id": "#/properties/application-data/alert_rules/groups/0/rules/0/labels",
+                                                        "title": "Labels of an individual alert rule",
+                                                        "type": "object",
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "annotations": {
+                                                        "$id": "#/properties/application-data/alert_rules/groups/0/rules/0/annotations",
+                                                        "title": "Annotations of an individual alert rule",
+                                                        "type": "object",
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "scrape_jobs": {
+                    "$id": "#/properties/application-data/scrape_jobs",
+                    "title": "Scrape jobs exposed by the provider",
+                    "type": "array",
+                    "additionalItems": true,
+                    "items": [
+                        {
+                            "$id": "#/properties/application-data/scrape_jobs/0",
+                            "title": "Scrape job exposed by the provider",
+                            "type": "object",
+                            "additionalProperties": true,
+                            "properties": {
+                                "metrics_path": {
+                                    "$id": "#/properties/application-data/scrape_jobs/0/metrics_path",
+                                    "title": "Path to the metrics endpoint",
+                                    "type": "string"
+                                },
+                                "static_configs": {
+                                    "$id": "#/properties/application-data/scrape_jobs/0/static_configs",
+                                    "title": "Static configs for a scrape job",
+                                    "type": "array",
+                                    "additionalItems": true,
+                                    "items": [
+                                        {
+                                            "$id": "#/properties/application-data/scrape_jobs/0/static/configs/0",
+                                            "title": "Static config for a scrape job",
+                                            "type": "object",
+                                            "additionalProperties": true,
+                                            "properties": {
+                                                "targets": {
+                                                    "$id": "#/properties/application-data/scrape_jobs/0/static/configs/0/targets",
+                                                    "title": "List of targets associated with a static config",
+                                                    "type": "array",
+                                                    "additionalItems": true,
+                                                    "items": [
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "targets"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "metrics_path",
+                                "static_configs"
+                            ]
+                        }
+                    ]
+                },
+                "scrape_metadata": {
+                    "$id": "#/properties/application-data/scrape_metadata",
+                    "title": "Scrape metadata associated with a provider",
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                        "model": {
+                            "$id": "#/properties/application-data/scrape_metadata/model",
+                            "title": "Juju model of a scrape endpoint provider",
+                            "type": "string"
+                        },
+                        "model_uuid": {
+                            "$id": "#/properties/application-data/scrape_metadata/model_uuid",
+                            "title": "Juju model UUID of a scrape endpoint provider",
+                            "type": "string"
+                        },
+                        "application": {
+                            "$id": "#/properties/application-data/scrape_metadata/application",
+                            "title": "Juju application name of a scrape endpoint provider",
+                            "type": "string"
+                        },
+                        "unit": {
+                            "$id": "#/properties/application-data/scrape_metadata/unit",
+                            "title": "Juju unit of a scrape endpoint provider",
+                            "type": "string"
+                        },
+                        "charm_name": {
+                            "$id": "#/properties/application-data/scrape_metadata/charm_name",
+                            "title": "Charm name of a scrape endpoint provider",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "model",
+                        "model_uuid",
+                        "application",
+                        "unit",
+                        "charm_name"
+                    ]
+                }
+            },
+            "required": [
+                "scrape_jobs",
+                "scrape_metadata"
+            ]
+        },
+        "related-units": {
+            "type": "object",
+            "patternProperties": {
+                "^.*/d+$": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                        "data": {
+                            "$id": "#/properties/related-units/unit/data",
+                            "title": "Unit databag",
+                            "type": "object",
+                            "additionalProperties": true,
+                            "properties": {
+                                "prometheus_scrape_unit_address": {
+                                    "$id": "#/properties/related-units/unit/data/prometheus_scrape_unit_address",
+                                    "title": "Address to the individual unit",
+                                    "type": "string"
+                                },
+                                "prometheus_scrape_unit_name": {
+                                    "$id": "#/properties/related-units/unit/data/prometheus_scrape_unit_name",
+                                    "title": "Juju unit name for the individual unit",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "prometheus_scrape_unit_address",
+                                "prometheus_scrape_unit_name"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "data"
+                    ]
+                }
+            }
+        }
+    },
+    "required": [
+        "application-data",
+        "related-units"
+    ]
+}

--- a/interfaces/prometheus_scrape/v0/schemas/requirer.json
+++ b/interfaces/prometheus_scrape/v0/schemas/requirer.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/prometheus_remote_write/schemas/requirer.json",
+    "type": "object",
+    "title": "`prometheus_remote_write` requirer root schema",
+    "description": "The `prometheus_remote_write` root schema comprises the entire requirer databag for this interface.",
+    "default": {},
+    "examples": [],
+    "additionalProperties": true,
+    "properties": {
+        "application-data": {
+            "$id": "#/properties/application-data",
+            "title": "Application Databag",
+            "type": "object",
+            "additionalProperties": true,
+        },
+        "related-units": {
+            "type": "object",
+            "patternProperties": {
+                "^.*/d+$": {
+                    "type": "object",
+                    "additionalProperties": true,
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Move all interfaces into a subfolder in preparation for the interface tester.
- Add `prometheus_scrape`

As part of documenting `prometheus_scrape`, I've moved its schema up a level, so that a single schema now would include both unit and application databags. If we agree on this change, it will have to be done on all the other interface schemas as well.