### PR TITLE
Fixes relation direction in the diagram

### DIFF
--- a/grafana_auth/README.md
+++ b/grafana_auth/README.md
@@ -11,8 +11,8 @@ The `requirer` is expected to allow configurable authentication to `Grafana`. an
 
 ```mermaid
 flowchart TD
-    Provider -- grafana-url--> Requirer
-    Requirer -- grafana-auth-config--> Provider
+    Requirer -- grafana-url--> Provider
+    Provider -- grafana-auth-config--> Requirer
 ```
 
 ## Behavior


### PR DESCRIPTION
`Provider` and `Requirer` are flipped in the diagram that can be found in `Direction` section