### PR TITLE
feat: Implementation of the ACME config interface

### DIFF
--- a/interfaces/acme_config/README.md
+++ b/interfaces/acme_config/README.md
@@ -36,10 +36,6 @@ compatible with the interface.
 
 [\[JSON Schema\]](./schemas/provider.json)
 
-### Requirer
-
-[\[JSON Schema\]](./schemas/requirer.json)
-
 #### Example
 
 ```yaml
@@ -54,3 +50,7 @@ application-data:
     "CF_API_KEY": "abcd1234efgh"
   }
 ```
+
+### Requirer
+
+[\[JSON Schema\]](./schemas/requirer.json)

--- a/interfaces/acme_config/README.md
+++ b/interfaces/acme_config/README.md
@@ -1,0 +1,56 @@
+# ACME Config
+
+## Usage
+
+This relation interface describes the expected behavior of any charm claiming to be able to provide configurations for another charm that uses the ACME protocol. You can read more about ACME [here](https://letsencrypt.org/docs/client-options/).
+
+## Direction
+
+The interface will consist of a provider and a requirer.
+
+```mermaid
+flowchart TD
+    Provider -- ACME Config--> Requirer
+```
+
+## Behavior
+
+Both the Requirer and the provider need to adhere to a certain set of criterias to be considered
+compatible with the interface.
+
+### Provider
+
+- Is expected to provide general configurations necessary to communicate with the ACME
+  server (`email`, `server`, `agree to terms of services`)
+- Is expected to provide the ACME challenge it wants (`DNS-01` or `HTTP-01`)
+- Is expected to provide the challenge specific configurations (optional)
+
+### Requirer
+
+- Is expected to use the ACME protocol with the provided configuration to retrieve TLS
+  certificates.
+
+## Relation Data
+
+### Provider
+
+[\[JSON Schema\]](./schemas/provider.json)
+
+### Requirer
+
+[\[JSON Schema\]](./schemas/requirer.json)
+
+#### Example
+
+```yaml
+application-data:
+  email: "example@canonical.com"
+  server: "https://www.lets_encrypt.com"
+  agree_tos: true
+  challenge_name: "DNS-01"
+  challenge_config: {
+    "provider": "cloudflare",
+    "CF_API_EMAIL": "example@canonical.com",
+    "CF_API_KEY": "abcd1234efgh"
+  }
+```

--- a/interfaces/acme_config/schemas/provider.json
+++ b/interfaces/acme_config/schemas/provider.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/acme_config/schemas/requirer.json",
+  "type": "object",
+  "title": "`acme_config` provider root schema",
+  "description": "The `acme_config` root schema comprises the entire requirer databag for this interface.",
+  "examples": [
+    {
+      "email": "example@canonical.com",
+      "server": "https://www.acme.com",
+      "agree_tos": true,
+      "challenge_name": "HTTP-01"
+    },
+    {
+      "email": "example@canonical.com",
+      "server": "https://www.acme.com",
+      "agree_tos": true,
+      "challenge_name": "DNS-01",
+      "challenge_config": {
+        "provider": "cloudflare",
+        "CF_API_EMAIL": "example@canonical.com",
+        "CF_API_KEY": "abcd1234efgh"
+      }
+    }
+  ],
+  "properties": {
+    "email": {
+      "type": "string"
+    },
+    "server": {
+      "type": "string"
+    },
+    "agree_tos": {
+      "type": "boolean"
+    },
+    "challenge_name": {
+      "type": "string"
+    },
+    "challenge_config": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "email",
+    "server",
+    "agree_tos",
+    "challenge_name"
+  ],
+  "additionalProperties": true
+}

--- a/interfaces/acme_config/schemas/requirer.json
+++ b/interfaces/acme_config/schemas/requirer.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/acme_config/schemas/provider.json",
+  "type": "object",
+  "title": "`acme_config` provider schema",
+  "description": "The `acme_config` root schema comprises the entire provider databag for this interface.",
+  "default": {},
+  "properties": {
+    "additionalProperties": true
+  }
+}


### PR DESCRIPTION
# Description

Implementation of the acme-config interface. The acme-config interface will be used by charms like traefik-k8s and certbot-k8s (to be implemented) that use the ACME protocol to retrieve their certificates.

## Example usage with traefik

Traefik already can use the ACME protocol to retrieve certificates and would only have to integrate with an acme-integrator charm to provide the configuration.

![tls_traefik](https://user-images.githubusercontent.com/18486508/199256628-852a66bb-aead-4d00-ab59-dddef4c0998d.png)

## Example usage with a charm that doesn't use ACME

Most charms don't use the ACME protocol. Here is an example that would leverage the tls-certificates interface and the acme-config interface to retrieve certificates.

![tls_ex2](https://user-images.githubusercontent.com/18486508/199257390-5942b4dd-86e9-48b8-aad0-c26e0365691d.png)

## Usage

The provider of this interface will specify generic configurations to be used by the charm using the ACME protocol as well as challenge specific configs:

### Example 1 (DNS-01 challenge)
```yaml
application-data:
  email: "example@canonical.com"
  server: "https://www.lets_encrypt.com"
  agree_tos: true
  challenge_name: "DNS-01"
  challenge_config: {
    "provider": "cloudflare",
    "CF_API_EMAIL": "example@canonical.com",
    "CF_API_KEY": "abcd1234efgh"
  }
```


### Example 2 (HTTP-01 challenge)
```yaml
application-data:
  email: "example@canonical.com"
  server: "https://www.lets_encrypt.com"
  agree_tos: true
  challenge_name: "HTTP-01"
```

