### PR TITLE
added interface directory template

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A catalogue of opinionated and standardized interface specifications for charmed
 ## Contributing
 To contribute an interface specification, open a pull request containing a `README.md`, json schemas for both sides of the relation, as well as a `charms.yaml` file consisting of a list of any `providers` and `consumers` known to adhere to the specification. See the [grafana-auth](https://github.com/canonical/charm-relation-interfaces/tree/main/interfaces/grafana_auth/v0) interface for examples of what to include and how it should be structured. For interface schemas, make sure to include **both the unit and application databag** in your schema, and also make sure to set `additionalProperties` to `true` as we want to be able to keep it extendable.
 
+To quickly get started, you can copy the `interfaces/__template__` folder to create a basic template.
+
 ## Interfaces
 
 | Interface                                                                    | Status                                                              |

--- a/interfaces/__template__/v0/README.md
+++ b/interfaces/__template__/v0/README.md
@@ -1,0 +1,67 @@
+# `ingress`
+
+## Usage
+
+Describe the expected usage of the relation interface.
+
+## Direction
+
+If this interface implements a provider/requirer pattern, describe the directionality of the relation and its meaning.
+It would be good to have a mermaid chart to explain further:
+
+```mermaid
+flowchart TD
+    Requirer -- DataForward --> Provider
+    Provider -- DataBack --> Requirer
+```
+
+## Behavior
+
+Describe as clearly as possible criteria that the requirer and the provider need to adhere to, to be considered compatible with the interface.
+
+### Provider
+
+- List of expectations that the provider needs to fulfill. For example
+- Is expected to publish the ingress url in its application databag.
+  The url is expected to have the following structure:
+
+    > `http://[ingress hostname]:[ingress port]/[app-name]-[model-name]/`
+    
+
+### Requirer
+
+- List of expectations that the requirer needs to fulfill. For example
+- Is expected to be able to provide a hostname, a port, the name of the (leader) unit requesting ingress, and a model name (namespace). 
+
+## Relation Data
+
+Describe the contents of the databags, and provide schemas for them.
+
+### Provider
+
+[\[JSON Schema\]](./schemas/provider.json)
+
+
+#### Example
+
+Provide examples of valid databags.
+
+```yaml
+application_data: {
+  url: "http://foo.bar:80/model_name-unit_name/0"
+}
+```
+
+### Requirer
+
+[\[JSON Schema\]](./schemas/requirer.json)
+
+#### Example
+```yaml
+application-data: {
+ name: "unit-name",
+ host: "hostname",
+ port: 4242,
+ model: "model-name"
+}
+```

--- a/interfaces/__template__/v0/charms.yaml
+++ b/interfaces/__template__/v0/charms.yaml
@@ -1,0 +1,4 @@
+providers:
+  - list of reference charms using the provider side
+consumers:
+  - list of reference charms using the consumer side

--- a/interfaces/__template__/v0/schemas/provider.json
+++ b/interfaces/__template__/v0/schemas/provider.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/<your-interface-name>/schemas/provider.json",
+    "type": "object",
+    "title": "`your-interface-name` provider schema",
+    "description": "The `your-interface-name` root schema comprises the entire provider databag for this interface.",
+    "default": {},
+    "examples": [
+        {
+        }
+    ],
+    "required": [
+    ],
+    "properties": {
+    },
+}

--- a/interfaces/__template__/v0/schemas/requirer.json
+++ b/interfaces/__template__/v0/schemas/requirer.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/<your-interface-name>/schemas/requirer.json",
+    "type": "object",
+    "title": "`your-interface-name` requirer schema",
+    "description": "The `your-interface-name` root schema comprises the entire requirer databag for this interface.",
+    "default": {},
+    "examples": [
+        {
+        }
+    ],
+    "required": [
+    ],
+    "properties": {
+    },
+}


### PR DESCRIPTION
added a `interfaces.__template__` folder:

```
./interfaces/__template__
└── v0
    ├── charms.yaml
    ├── README.md
    └── schemas
        ├── provider.json
        └── requirer.json
```

That should help users quickly get started contributing their interface.
Also, when we add the interface testers, we are going to add `interfaces/__template__/v0/interface_tests/interface_tests.py` to the template, which is going to be very useful to get people used to the testing framework.
