### PR TITLE
Add draft opensearch interface 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Charm Relation Interfaces
 
-A catalogue of opinionated and standardized interface specifications for charmed operator relations. The purpose of the repository is to outline the behavior and requirements for key interface names, ensuring that charms claiming to implement a certain interface actually are capable of being integrated with each other. 
+A catalogue of opinionated and standardized interface specifications for charmed operator relations. The purpose of the repository is to outline the behavior and requirements for key interface names, ensuring that charms claiming to implement a certain interface actually are capable of being integrated with each other.
 
 ## Contributing
 To contribute an interface specification, open a pull request containing a `README.md`, json schemas for both sides of the relation, as well as a `charms.yaml` file consisting of a list of any `providers` and `consumers` known to adhere to the specification. See the [grafana-auth](https://github.com/canonical/charm-relation-interfaces/tree/main/interfaces/grafana_auth/v0) interface for examples of what to include and how it should be structured. For interface schemas, make sure to include **both the unit and application databag** in your schema, and also make sure to set `additionalProperties` to `true` as we want to be able to keep it extendable.
@@ -9,12 +9,13 @@ To quickly get started, you can copy the `interfaces/__template__` folder to cre
 
 ## Interfaces
 
-| Category      | Interface                                                                    |                               Status                                | 
+| Category      | Interface                                                                    |                               Status                                |
 |---------------|:-----------------------------------------------------------------------------|:-------------------------------------------------------------------:|
 | Data          | [`mysql_client`](interfaces/mysql_client/v0/README.md)                       | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 |               | [`postgresql_client`](interfaces/postgresql_client/v0/README.md)             | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 |               | [`mongodb_client`](interfaces/mongodb_client/v0/README.md)                   | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 |               | [`kafka_client`](interfaces/kafka_client/v0/README.md)                       | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+|               | [`opensearch_client`](interfaces/opensearch_client/v0/README.md)             | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 |               | [`database_backup`](interfaces/database_backup/v0/README.md)                 | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 | Observability | [`grafana_auth`](interfaces/grafana_auth/v0/README.md)                       | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 |               | [`ingress`](interfaces/ingress/v0/README.md)                                 | ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen) |

--- a/interfaces/opensearch_client/v0/README.md
+++ b/interfaces/opensearch_client/v0/README.md
@@ -31,7 +31,7 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
 
 - Is expected to provide an index name in the `index` field.
   - This index is NOT removed from the opensearch charm when the relation is removed.
-- Is expected to provide indentical values in the `index` field if several requirer units provide it in the relation.
+- Is expected to provide identical values in the `index` field if several requirer units provide it in the relation.
 - Is expected to have unique credentials for each relation. Therefore, different instances of the same Charm (juju applications) will have different relations with different credentials.
 - Is expected to have different relations with the same interface name if Requirer needs access to multiple opensearch charms.
 - Is expected to allow multiple different charmed applications to access the same index name.

--- a/interfaces/opensearch_client/v0/README.md
+++ b/interfaces/opensearch_client/v0/README.md
@@ -21,15 +21,15 @@ As with all Juju relations, the `database` interface consists of two parties: a 
 Both the Requirer and the Provider need to adhere to criteria to be considered compatible with the interface.
 
 ### Provider
-- Is expected to create an application user inside the opensearch cluster when the requirer provides the `database` field.
-- Is expected to provide `username` and `password` fields when Requirer provides the `database` field.
-- Is expected to provide the `endpoints` field containing all cluster host addresses in a comma-separated list.
+- Is expected to create an application user inside the opensearch cluster when the requirer provides the `index` field.
+- Is expected to provide `username` and `password` fields when Requirer provides the `index` field.
+- Is expected to provide the `hosts` field containing all cluster host addresses in a comma-separated list.
 - Is expected to provide the `version` field describing the installed version of opensearch.
 
 ### Requirer
 
-- Is expected to provide an index name in the `database` field.
-- Is expected to provide indentical values in the `database` field if several requirer units provide it in the relation.
+- Is expected to provide an index name in the `index` field.
+- Is expected to provide indentical values in the `index` field if several requirer units provide it in the relation.
 - Is expected to have unique credentials for each relation. Therefore, different instances of the same Charm (juju applications) will have different relations with different credentials.
 - Is expected to have different relations names on Requirer with the same interface name if Requirer needs access to multiple database charms.
 - Is expected to allow multiple different Juju applications to access the same database name.
@@ -44,7 +44,7 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
 
 [\[JSON Schema\]](./schemas/provider.json)
 
-Provider provides credentials, endpoints, TLS info and database-specific fields. It should be placed in the **application** databag.
+Provider provides credentials, host addresses, TLS info and database-specific fields. It should be placed in the **application** databag.
 
 
 #### Example
@@ -53,8 +53,8 @@ Provider provides credentials, endpoints, TLS info and database-specific fields.
   - endpoint: database
     related-endpoint: database
     application-data:
-      database: myindex
-      endpoints: 10.180.162.200:9200,10.180.162.75:9200
+      index: myindex
+      hosts: 10.180.162.200:9200,10.180.162.75:9200
       password: Dy0k2UTfyNt2B13cfe412K7YGs07S4U7
       username: opensearch-client_4_user
 ```
@@ -63,8 +63,7 @@ Provider provides credentials, endpoints, TLS info and database-specific fields.
 
 [\[JSON Schema\]](./schemas/requirer.json)
 
-Requirer provides index name in `database` unit. Should be placed in the **unit** databag
-in at least one unit of the Requirer.
+Requirer provides index name. This should be placed in the **unit** databag in at least one unit of the Requirer.
 
 #### Example
 
@@ -77,5 +76,5 @@ in at least one unit of the Requirer.
       worker-a/0:
         in-scope: true
         data:
-          database: myindex
+          index: myindex
 ```

--- a/interfaces/opensearch_client/v0/README.md
+++ b/interfaces/opensearch_client/v0/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-This relation interface describes the expected behaviour of any charm interfacing with OpenSearch or ElasticSearch charms, such as the [Charmed OpenSearch Operator](https://github.com/canonical/opensearch-operator) using the `opensearch-client` relation.
+This relation interface describes the expected behaviour of any charm interfacing with OpenSearch or ElasticSearch charms, such as the [Charmed OpenSearch Operator](https://github.com/canonical/opensearch-operator) using the `opensearch-client` relation.  This interface is likely to satisfy the requirements of any ElasticSearch API-compatible application, but feel free to [open a PR](https://github.com/canonical/charm-relation-interfaces/pulls) to modify this document if it doesn't meet your requirements.
 
 In most cases, this will be accomplished using the [data_interfaces library](https://github.com/canonical/data-platform-libs/blob/main/lib/charms/data_platform_libs/v0/data_interfaces.py), although charm developers are free to provide alternative libraries as long as they fulfil the behavioural and schematic requirements described in this document.
 

--- a/interfaces/opensearch_client/v0/README.md
+++ b/interfaces/opensearch_client/v0/README.md
@@ -22,6 +22,7 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
 
 ### Provider
 - Is expected to create an application user inside the opensearch cluster when the requirer provides the `index` field.
+  - This user is removed when the relation is removed.
 - Is expected to provide `username` and `password` fields when Requirer provides the `index` field.
 - Is expected to provide the `endpoints` field containing all cluster endpoint addresses in a comma-separated list.
 - Is expected to provide the `version` field describing the installed version of opensearch.
@@ -29,9 +30,10 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
 ### Requirer
 
 - Is expected to provide an index name in the `index` field.
+  - This index is NOT removed from the opensearch charm when the relation is removed.
 - Is expected to provide indentical values in the `index` field if several requirer units provide it in the relation.
 - Is expected to have unique credentials for each relation. Therefore, different instances of the same Charm (juju applications) will have different relations with different credentials.
-- Is expected to have different relations names on Requirer with the same interface name if Requirer needs access to multiple opensearch charms.
+- Is expected to have different relations with the same interface name if Requirer needs access to multiple opensearch charms.
 - Is expected to allow multiple different charmed applications to access the same index name.
 - Is expected to add any `extra-user-roles` provided by the Requirer to the created user (e.g. `extra-user-roles=admin`).
   - This can be set to two values:

--- a/interfaces/opensearch_client/v0/README.md
+++ b/interfaces/opensearch_client/v0/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-This relation interface describes the expected behaviour of any charm claiming to be able to interact with an opensearch index.
+This relation interface describes the expected behaviour of any charm interfacing with the [Charmed Opensearch Operator](https://github.com/canonical/opensearch-operator) using the `opensearch-client` relation.
 
 In most cases, this will be accomplished using the [data_interfaces library](https://github.com/canonical/data-platform-libs/blob/main/lib/charms/data_platform_libs/v0/data_interfaces.py), although charm developers are free to provide alternative libraries as long as they fulfil the behavioural and schematic requirements described in this document.
 
@@ -14,7 +14,7 @@ flowchart TD
     Provider -- username, \npassword, \nendpoints --> Requirer
 ```
 
-As with all Juju relations, the `database` interface consists of two parties: a Provider (opensearch charm), and a Requirer (application charm). The Requirer will be expected to provide an index name, and the Provider will provide new unique credentials (along with other optional fields), which can be used to access the index itself.
+As with all Juju relations, the `opensearch-client` interface consists of two parties: a Provider (opensearch charm), and a Requirer (application charm). The Requirer will be expected to provide an index name, and the Provider will provide new unique credentials (along with other optional fields), which can be used to access the index itself.
 
 ## Behavior
 
@@ -23,7 +23,7 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
 ### Provider
 - Is expected to create an application user inside the opensearch cluster when the requirer provides the `index` field.
 - Is expected to provide `username` and `password` fields when Requirer provides the `index` field.
-- Is expected to provide the `hosts` field containing all cluster host addresses in a comma-separated list.
+- Is expected to provide the `endpoints` field containing all cluster endpoint addresses in a comma-separated list.
 - Is expected to provide the `version` field describing the installed version of opensearch.
 
 ### Requirer
@@ -44,17 +44,17 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
 
 [\[JSON Schema\]](./schemas/provider.json)
 
-Provider provides credentials, host addresses, TLS info and database-specific fields. It should be placed in the **application** databag.
+Provider provides credentials, endpoint addresses, TLS info and database-specific fields. It should be placed in the **application** databag.
 
 
 #### Example
 ```yaml
   relation-info:
-  - endpoint: database
-    related-endpoint: database
+  - endpoint: opensearch-client
+    related-endpoint: opensearch-app-consumer
     application-data:
       index: myindex
-      hosts: 10.180.162.200:9200,10.180.162.75:9200
+      endpoints: 10.180.162.200:9200,10.180.162.75:9200
       password: Dy0k2UTfyNt2B13cfe412K7YGs07S4U7
       username: opensearch-client_4_user
 ```
@@ -69,8 +69,8 @@ Requirer provides index name. This should be placed in the **unit** databag in a
 
 ```yaml
   relation-info:
-  - endpoint: database
-    related-endpoint: database
+  - endpoint: opensearch-app-consumer
+    related-endpoint: opensearch-client
     application-data: {}
     related-units:
       worker-a/0:

--- a/interfaces/opensearch_client/v0/README.md
+++ b/interfaces/opensearch_client/v0/README.md
@@ -14,7 +14,7 @@ flowchart TD
     Provider -- username, \npassword, \nendpoints --> Requirer
 ```
 
-As with all Juju relations, the `database` interface consists of two parties: a Provider (database charm), and a Requirer (application charm). The Requirer will be expected to provide an index name, and the Provider will provide new unique credentials (along with other optional fields), which can be used to access the index itself.
+As with all Juju relations, the `database` interface consists of two parties: a Provider (opensearch charm), and a Requirer (application charm). The Requirer will be expected to provide an index name, and the Provider will provide new unique credentials (along with other optional fields), which can be used to access the index itself.
 
 ## Behavior
 
@@ -24,7 +24,7 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
 - Is expected to create an application user inside the opensearch cluster when the requirer provides the `database` field.
 - Is expected to provide `username` and `password` fields when Requirer provides the `database` field.
 - Is expected to provide the `endpoints` field containing all cluster host addresses in a comma-separated list.
-- Is expected to provide the `version` field whenever database charm wants to communicate its database version.
+- Is expected to provide the `version` field describing the installed version of opensearch.
 
 ### Requirer
 
@@ -34,7 +34,9 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
 - Is expected to have different relations names on Requirer with the same interface name if Requirer needs access to multiple database charms.
 - Is expected to allow multiple different Juju applications to access the same database name.
 - Is expected to add any `extra-user-roles` provided by the Requirer to the created user (e.g. `extra-user-roles=admin`).
-  - If this is not set to a default
+  - This can be set to two values:
+    - default: this has read-write permissions over the index that has been generated for this relation.
+    - admin: this has control over the index, including how cluster roles are assigned to nodes in the cluster.
 
 ## Relation Data
 

--- a/interfaces/opensearch_client/v0/README.md
+++ b/interfaces/opensearch_client/v0/README.md
@@ -52,7 +52,7 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
 
 [\[JSON Schema\]](./schemas/provider.json)
 
-Provider provides credentials, endpoint addresses, TLS info and index-specific fields. It should be placed in the **application** databag.
+Provider provides credentials, endpoint addresses, TLS info and index-specific fields in the **application** databag.
 
 
 #### Example

--- a/interfaces/opensearch_client/v0/README.md
+++ b/interfaces/opensearch_client/v0/README.md
@@ -71,7 +71,7 @@ Provider provides credentials, endpoint addresses, TLS info and index-specific f
 
 [\[JSON Schema\]](./schemas/requirer.json)
 
-Requirer provides index name. This should be placed in the **unit** databag in at least one unit of the Requirer.
+Requirer provides the index name in its **unit** databag.
 
 #### Example
 

--- a/interfaces/opensearch_client/v0/README.md
+++ b/interfaces/opensearch_client/v0/README.md
@@ -41,9 +41,9 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
   - This index is NOT removed from the provider charm when the relation is removed.
 - Is expected to have different relations with the same interface name if Requirer needs access to multiple opensearch indices.
 - Is expected to provide user permissions in the `extra-user-roles` field. These permissions will be applied to the user created for the relation.
-  - These permissions can be set to two values:
-    - default: this has read-write permissions over the index that has been generated for this relation. This permission level will be applied if no value is provided.
-    - admin: this has control over the index, including how cluster roles are assigned to nodes in the cluster.
+  - This value can be empty, in which case a default will be applied, or it can be set to `admin`:
+    - default: this has read-write permissions over the index that has been generated for this relation.
+    - admin: this has control over the cluster, including creating new indices and setting cluster node roles.
   - Specifics of how these permissions are implemented have been left to the provider charm developers, since they vary slightly between opensearch API-compliant applications.
 
 ## Relation Data
@@ -61,7 +61,6 @@ Provider provides credentials, endpoint addresses, TLS info and index-specific f
   - endpoint: opensearch-client
     related-endpoint: opensearch-app-consumer
     application-data:
-      index: myindex
       endpoints: 10.180.162.200:9200,10.180.162.75:9200
       password: Dy0k2UTfyNt2B13cfe412K7YGs07S4U7
       username: opensearch-client_4_user

--- a/interfaces/opensearch_client/v0/README.md
+++ b/interfaces/opensearch_client/v0/README.md
@@ -31,11 +31,11 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
 - Is expected to provide an index name in the `index` field.
 - Is expected to provide indentical values in the `index` field if several requirer units provide it in the relation.
 - Is expected to have unique credentials for each relation. Therefore, different instances of the same Charm (juju applications) will have different relations with different credentials.
-- Is expected to have different relations names on Requirer with the same interface name if Requirer needs access to multiple database charms.
-- Is expected to allow multiple different Juju applications to access the same database name.
+- Is expected to have different relations names on Requirer with the same interface name if Requirer needs access to multiple opensearch charms.
+- Is expected to allow multiple different charmed applications to access the same index name.
 - Is expected to add any `extra-user-roles` provided by the Requirer to the created user (e.g. `extra-user-roles=admin`).
   - This can be set to two values:
-    - default: this has read-write permissions over the index that has been generated for this relation.
+    - default: this has read-write permissions over the index that has been generated for this relation. This permission level will be applied if no value is provided.
     - admin: this has control over the index, including how cluster roles are assigned to nodes in the cluster.
 
 ## Relation Data

--- a/interfaces/opensearch_client/v0/README.md
+++ b/interfaces/opensearch_client/v0/README.md
@@ -1,0 +1,79 @@
+# `opensearch_client`
+
+## Usage
+
+This relation interface describes the expected behaviour of any charm claiming to be able to interact with an opensearch index.
+
+In most cases, this will be accomplished using the [data_interfaces library](https://github.com/canonical/data-platform-libs/blob/main/lib/charms/data_platform_libs/v0/data_interfaces.py), although charm developers are free to provide alternative libraries as long as they fulfil the behavioural and schematic requirements described in this document.
+
+## Direction
+
+```mermaid
+flowchart TD
+    Requirer -- database, \nextra-user-roles --> Provider
+    Provider -- username, \npassword, \nendpoints --> Requirer
+```
+
+As with all Juju relations, the `database` interface consists of two parties: a Provider (database charm), and a Requirer (application charm). The Requirer will be expected to provide an index name, and the Provider will provide new unique credentials (along with other optional fields), which can be used to access the index itself.
+
+## Behavior
+
+Both the Requirer and the Provider need to adhere to criteria to be considered compatible with the interface.
+
+### Provider
+- Is expected to create an application user inside the opensearch cluster when the requirer provides the `database` field.
+- Is expected to provide `username` and `password` fields when Requirer provides the `database` field.
+- Is expected to provide the `endpoints` field containing all cluster host addresses in a comma-separated list.
+- Is expected to provide the `version` field whenever database charm wants to communicate its database version.
+
+### Requirer
+
+- Is expected to provide an index name in the `database` field.
+- Is expected to provide indentical values in the `database` field if several requirer units provide it in the relation.
+- Is expected to have unique credentials for each relation. Therefore, different instances of the same Charm (juju applications) will have different relations with different credentials.
+- Is expected to have different relations names on Requirer with the same interface name if Requirer needs access to multiple database charms.
+- Is expected to allow multiple different Juju applications to access the same database name.
+- Is expected to add any `extra-user-roles` provided by the Requirer to the created user (e.g. `extra-user-roles=admin`).
+  - If this is not set to a default
+
+## Relation Data
+
+### Provider
+
+[\[JSON Schema\]](./schemas/provider.json)
+
+Provider provides credentials, endpoints, TLS info and database-specific fields. It should be placed in the **application** databag.
+
+
+#### Example
+```yaml
+  relation-info:
+  - endpoint: database
+    related-endpoint: database
+    application-data:
+      database: myindex
+      endpoints: 10.180.162.200:9200,10.180.162.75:9200
+      password: Dy0k2UTfyNt2B13cfe412K7YGs07S4U7
+      username: opensearch-client_4_user
+```
+
+### Requirer
+
+[\[JSON Schema\]](./schemas/requirer.json)
+
+Requirer provides index name in `database` unit. Should be placed in the **unit** databag
+in at least one unit of the Requirer.
+
+#### Example
+
+```yaml
+  relation-info:
+  - endpoint: database
+    related-endpoint: database
+    application-data: {}
+    related-units:
+      worker-a/0:
+        in-scope: true
+        data:
+          database: myindex
+```

--- a/interfaces/opensearch_client/v0/README.md
+++ b/interfaces/opensearch_client/v0/README.md
@@ -28,9 +28,9 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
   - If multiple relations require the same index name, they should all be able to access it.
 - Is not expected to create an index on relation creation.
   - Responsibility for managing an index rests with the requirer application, including creating and removing indices.
-- Is expected to provide `username` and `password` fields as Juju Secrets when Requirer provides the `index` field.
+- Is expected to provide unique `username` and `password` fields as Juju Secrets when Requirer provides the `index` field.
 - Is expected to provide the `endpoints` field containing all cluster endpoint addresses in a comma-separated list.
-- Is expected to provide the `version` field describing the installed version of opensearch.
+- Is expected to provide the `version` field describing the installed version number of opensearch.
 - If the charm has TLS enabled (such as using the [TLS Certificates Operator](https://github.com/canonical/tls-certificates-operator)), it is expected to provide the CA chain in the `tls-ca` field as a Juju Secret.
 
 ### Requirer
@@ -41,9 +41,10 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
   - This index is NOT removed from the provider charm when the relation is removed.
 - Is expected to have different relations with the same interface name if Requirer needs access to multiple opensearch indices.
 - Is expected to provide user permissions in the `extra-user-roles` field. These permissions will be applied to the user created for the relation.
-  - This can be set to two values:
+  - These permissions can be set to two values:
     - default: this has read-write permissions over the index that has been generated for this relation. This permission level will be applied if no value is provided.
     - admin: this has control over the index, including how cluster roles are assigned to nodes in the cluster.
+  - Specifics of how these permissions are implemented have been left to the provider charm developers, since they vary slightly between opensearch API-compliant applications.
 
 ## Relation Data
 
@@ -51,7 +52,7 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
 
 [\[JSON Schema\]](./schemas/provider.json)
 
-Provider provides credentials, endpoint addresses, TLS info and database-specific fields. It should be placed in the **application** databag.
+Provider provides credentials, endpoint addresses, TLS info and index-specific fields. It should be placed in the **application** databag.
 
 
 #### Example

--- a/interfaces/opensearch_client/v0/charms.yaml
+++ b/interfaces/opensearch_client/v0/charms.yaml
@@ -1,0 +1,3 @@
+providers:
+  - opensearch-operator
+consumers: []

--- a/interfaces/opensearch_client/v0/schemas/provider.json
+++ b/interfaces/opensearch_client/v0/schemas/provider.json
@@ -8,7 +8,7 @@
     "required": [
         "username",
         "password",
-        "hosts"
+        "endpoints"
     ],
     "additionalProperties": true,
     "properties": {
@@ -32,10 +32,10 @@
                 "alphanum-32byte-random"
             ]
         },
-        "hosts": {
-            "$id": "#/properties/hosts",
-            "title": "Database Hosts",
-            "description": "A list of hosts used to connect to the index",
+        "endpoints": {
+            "$id": "#/properties/endpoints",
+            "title": "Database endpoints",
+            "description": "A list of endpoints used to connect to the index",
             "type": "string",
             "default": "",
             "examples": [
@@ -57,7 +57,7 @@
         "username": "opensearch-client_0_user",
         "password": "alphanum-32byte-random",
         "index": "myapp",
-        "hosts": "ip-1:port,ip-2:port",
+        "endpoints": "ip-1:port,ip-2:port",
         "version": "8.0.27-18"
     }]
 }

--- a/interfaces/opensearch_client/v0/schemas/provider.json
+++ b/interfaces/opensearch_client/v0/schemas/provider.json
@@ -15,7 +15,7 @@
         "username": {
             "$id": "#/properties/username",
             "title": "Database User Username",
-            "description": "Username for connecting to the requested database",
+            "description": "Username for connecting to the requested index",
             "type": "string",
             "default": "",
             "examples": [
@@ -25,21 +25,11 @@
         "password": {
             "$id": "#/properties/password",
             "title": "Database User Password",
-            "description": "Password for connecting to the requested database",
+            "description": "Password for connecting to the requested index",
             "type": "string",
             "default": "",
             "examples": [
                 "alphanum-32byte-random"
-            ]
-        },
-        "database": {
-            "$id": "#/properties/database",
-            "title": "Database Name",
-            "description": "The index name delivered by the provider. Might not be the same as requested by the requirer",
-            "type": "string",
-            "default": "",
-            "examples": [
-                "myapp"
             ]
         },
         "endpoints": {

--- a/interfaces/opensearch_client/v0/schemas/provider.json
+++ b/interfaces/opensearch_client/v0/schemas/provider.json
@@ -1,0 +1,73 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/opensearch_client/schemas/provider.json",
+    "title": "`opensearch_client` provider schema",
+    "description": "The `opensearch_client` root schema comprises the entire provider databag for this interface.",
+    "type": "object",
+    "default": {},
+    "required": [
+        "username",
+        "password",
+        "endpoints"
+    ],
+    "additionalProperties": true,
+    "properties": {
+        "username": {
+            "$id": "#/properties/username",
+            "title": "Database User Username",
+            "description": "Username for connecting to the requested database",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "opensearch-client_0_user"
+            ]
+        },
+        "password": {
+            "$id": "#/properties/password",
+            "title": "Database User Password",
+            "description": "Password for connecting to the requested database",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "alphanum-32byte-random"
+            ]
+        },
+        "database": {
+            "$id": "#/properties/database",
+            "title": "Database Name",
+            "description": "The index name delivered by the provider. Might not be the same as requested by the requirer",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "myapp"
+            ]
+        },
+        "endpoints": {
+            "$id": "#/properties/endpoints",
+            "title": "Database Endpoints",
+            "description": "A list of database endpoints used to connect to the index",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "unit-1:port,unit-2:port"
+            ]
+        },
+        "version": {
+            "$id": "#/properties/version",
+            "title": "Version",
+            "description": "The version of opensearch",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "8.0.27-18"
+            ]
+        }
+    },
+    "examples": [{
+        "username": "opensearch-client_0_user",
+        "password": "alphanum-32byte-random",
+        "database": "myapp",
+        "endpoints": "ip-1:port,ip-2:port",
+        "version": "8.0.27-18"
+    }]
+}

--- a/interfaces/opensearch_client/v0/schemas/provider.json
+++ b/interfaces/opensearch_client/v0/schemas/provider.json
@@ -8,7 +8,7 @@
     "required": [
         "username",
         "password",
-        "endpoints"
+        "hosts"
     ],
     "additionalProperties": true,
     "properties": {
@@ -32,10 +32,10 @@
                 "alphanum-32byte-random"
             ]
         },
-        "endpoints": {
-            "$id": "#/properties/endpoints",
-            "title": "Database Endpoints",
-            "description": "A list of database endpoints used to connect to the index",
+        "hosts": {
+            "$id": "#/properties/hosts",
+            "title": "Database Hosts",
+            "description": "A list of hosts used to connect to the index",
             "type": "string",
             "default": "",
             "examples": [
@@ -56,8 +56,8 @@
     "examples": [{
         "username": "opensearch-client_0_user",
         "password": "alphanum-32byte-random",
-        "database": "myapp",
-        "endpoints": "ip-1:port,ip-2:port",
+        "index": "myapp",
+        "hosts": "ip-1:port,ip-2:port",
         "version": "8.0.27-18"
     }]
 }

--- a/interfaces/opensearch_client/v0/schemas/provider.json
+++ b/interfaces/opensearch_client/v0/schemas/provider.json
@@ -39,7 +39,7 @@
             "type": "string",
             "default": "",
             "examples": [
-                "unit-1:port,unit-2:port"
+                "unit-1:9200,unit-2:9200"
             ]
         },
         "version": {
@@ -57,7 +57,7 @@
         "username": "opensearch-client_0_user",
         "password": "alphanum-32byte-random",
         "index": "myapp",
-        "endpoints": "ip-1:port,ip-2:port",
+        "endpoints": "ip-1:9200,ip-2:9200",
         "version": "8.0.27-18"
     }]
 }

--- a/interfaces/opensearch_client/v0/schemas/provider.json
+++ b/interfaces/opensearch_client/v0/schemas/provider.json
@@ -14,7 +14,7 @@
     "properties": {
         "username": {
             "$id": "#/properties/username",
-            "title": "Database User Username",
+            "title": "Relation User Username",
             "description": "Username for connecting to the requested index",
             "type": "string",
             "default": "",
@@ -24,7 +24,7 @@
         },
         "password": {
             "$id": "#/properties/password",
-            "title": "Database User Password",
+            "title": "Relation User Password",
             "description": "Password for connecting to the requested index",
             "type": "string",
             "default": "",
@@ -34,7 +34,7 @@
         },
         "endpoints": {
             "$id": "#/properties/endpoints",
-            "title": "Database endpoints",
+            "title": "Relation endpoints",
             "description": "A list of endpoints used to connect to the index",
             "type": "string",
             "default": "",

--- a/interfaces/opensearch_client/v0/schemas/requirer.json
+++ b/interfaces/opensearch_client/v0/schemas/requirer.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/opensearch_client/schemas/requirer.json",
+    "title": "`opensearch_client` requirer schema",
+    "description": "The `opensearch_client` root schema comprises the entire requirer databag for this interface.",
+    "type": "object",
+    "default": {},
+    "required": [
+        "database"
+    ],
+    "additionalProperties": true,
+    "properties": {
+        "database": {
+            "title": "Index Name",
+            "description": "The database name requested by the requirer",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "myapp"
+            ]
+        },
+        "extra-user-roles": {
+            "title": "Extra-user-roles",
+            "description": "Any extra user roles requested by the requirer",
+            "type": "string",
+            "default": "default",
+            "examples": [
+                "default,admin"
+            ]
+        }
+    },
+    "examples": [{
+        "database": "myapp",
+        "extra-user-roles": "default,admin"
+    }]
+}

--- a/interfaces/opensearch_client/v0/schemas/requirer.json
+++ b/interfaces/opensearch_client/v0/schemas/requirer.json
@@ -6,13 +6,13 @@
     "type": "object",
     "default": {},
     "required": [
-        "database"
+        "index"
     ],
     "additionalProperties": true,
     "properties": {
-        "database": {
+        "index": {
             "title": "Index Name",
-            "description": "The database name requested by the requirer",
+            "description": "The index name requested by the requirer",
             "type": "string",
             "default": "",
             "examples": [
@@ -30,7 +30,7 @@
         }
     },
     "examples": [{
-        "database": "myapp",
+        "index": "myindex",
         "extra-user-roles": "default,admin"
     }]
 }


### PR DESCRIPTION
This is a first draft spec for the opensearch interface 
- `database` field has been replaced with `index`
- `read_only_endpoints` aren't in this relation, since they're not really relevant to opensearch. 

 I'm still fixing up the tests, but you can see the interface in action [here](https://github.com/canonical/opensearch-operator/pull/30/). 

The spec is detailed below: 

---

# `opensearch_client`

## Usage

This relation interface describes the expected behaviour of any charm interfacing with OpenSearch or ElasticSearch charms, such as the [Charmed OpenSearch Operator](https://github.com/canonical/opensearch-operator) using the `opensearch-client` relation.

In most cases, this will be accomplished using the [data_interfaces library](https://github.com/canonical/data-platform-libs/blob/main/lib/charms/data_platform_libs/v0/data_interfaces.py), although charm developers are free to provide alternative libraries as long as they fulfil the behavioural and schematic requirements described in this document.

## Direction

```mermaid
flowchart TD
    Requirer -- index, \nextra-user-roles --> Provider
    Provider -- username, \npassword, \nendpoints --> Requirer
```

As with all Juju relations, the `opensearch-client` interface consists of two parties: a Provider (opensearch charm), and a Requirer (application charm). The Requirer will be expected to provide an index name, and the Provider will provide new unique credentials (along with other optional fields), which can be used to access the index itself.

## Behavior

Both the Requirer and the Provider need to adhere to criteria to be considered compatible with the interface.

### Provider

- Is expected to create an application user inside the opensearch cluster when the requirer provides the `index` field.
  - This user is removed when the relation is removed.
  - Is expected to apply the permissions in the `extra-user-roles` provided by the Requirer to this user (e.g. `extra-user-roles=admin`).
  - If multiple relations require the same index name, they should all be able to access it.
- Is not expected to create an index on relation creation.
  - Responsibility for managing an index rests with the requirer application, including creating and removing indices.
- Is expected to provide `username` and `password` fields as Juju Secrets when Requirer provides the `index` field.
- Is expected to provide the `endpoints` field containing all cluster endpoint addresses in a comma-separated list.
- Is expected to provide the `version` field describing the installed version of opensearch.
- If the charm has TLS enabled (such as using the [TLS Certificates Operator](https://github.com/canonical/tls-certificates-operator)), it is expected to provide the CA chain in the `tls-ca` field as a Juju Secret.

### Requirer

- Is expected to provide an index name in the `index` field.
- Is expected to manage its own index.
  - Indices are not created on the provider application when the relation is created. The `index` field exists to grant the correct permissions for the relation user, which the requirer charm uses to control its index.
  - This index is NOT removed from the provider charm when the relation is removed.
- Is expected to have different relations with the same interface name if Requirer needs access to multiple opensearch indices.
- Is expected to provide user permissions in the `extra-user-roles` field. These permissions will be applied to the user created for the relation.
  - This can be set to two values:
    - default: this has read-write permissions over the index that has been generated for this relation. This permission level will be applied if no value is provided.
    - admin: this has control over the index, including how cluster roles are assigned to nodes in the cluster.

## Relation Data

### Provider

[\[JSON Schema\]](./schemas/provider.json)

Provider provides credentials, endpoint addresses, TLS info and database-specific fields. It should be placed in the **application** databag.


#### Example
```yaml
  relation-info:
  - endpoint: opensearch-client
    related-endpoint: opensearch-app-consumer
    application-data:
      index: myindex
      endpoints: 10.180.162.200:9200,10.180.162.75:9200
      password: Dy0k2UTfyNt2B13cfe412K7YGs07S4U7
      username: opensearch-client_4_user
```

### Requirer

[\[JSON Schema\]](./schemas/requirer.json)

Requirer provides index name. This should be placed in the **unit** databag in at least one unit of the Requirer.

#### Example

```yaml
  relation-info:
  - endpoint: opensearch-app-consumer
    related-endpoint: opensearch-client
    application-data: {}
    related-units:
      worker-a/0:
        in-scope: true
        data:
          index: myindex
```
