### PR TITLE
[MISC] Adding optional consumer-group-prefix to the set of parameters…

### DIFF
--- a/interfaces/kafka_client/v0/README.md
+++ b/interfaces/kafka_client/v0/README.md
@@ -12,7 +12,7 @@ This relation interface describes the expected behavior of any charm claiming to
 
 ```mermaid
 flowchart LR
-    Requirer -- topic, extra-user-roles --> Provider
+    Requirer -- topic, extra-user-roles, consumer-group-prefix --> Provider
     Provider -- topic, username, password, endpoints, consumer-group-prefix, zookeeper-uris --> Requirer
 ```
 
@@ -32,7 +32,7 @@ Both the Requirer and the Provider need to adhere to the criteria, to be conside
 - Is expected to provide the `extra-user-roles` field specifying a comma-separated list of roles for the client application (between `admin`, `consumer` and `producer`).
 - Can optionally provide the `topic` field specifying the topic that the requirer charm needs permissions to create (for `extra-user-roles=producer`), or consume (for `extra-user-roles=consumer`).
 - Is expected to tolerate that the Provider may ignore the `topic` field in some cases and instead use the topic name received.
-
+- Can optionally provide the `consumer-group-prefix` field specifying the consumer-group-prefix that the requirer charm needs permissions to consume (for `extra-user-roles=consumer`).
 
 ## Relation Data
 
@@ -72,4 +72,5 @@ Requirer provides application role and topic. It should be placed in the **appli
     application-data:
         extra-user-roles: consumer,producer
         topic: special-topic
+        consumer-group-prefix: "my-consumer-group"
 ```

--- a/interfaces/kafka_client/v0/schemas/requirer.json
+++ b/interfaces/kafka_client/v0/schemas/requirer.json
@@ -69,12 +69,22 @@
             "topic-1",
             "appname-*"
          ]
+      },
+      "consumer-group-prefix":{
+         "title":"Kafka consumer group prefix",
+         "description":"A prefix for wildcard consumer-group ids that have been granted permissions",
+         "type":"string",
+         "default":"",
+         "examples":[
+            "relation-14-"
+         ]
       }
    },
    "examples":[
       {
          "extra-user-roles":"consumer",
-         "topic":"special-topic"
+         "topic":"special-topic",
+         "consumer-group-prefix": "my-consumer-group"
       }
    ]
 }


### PR DESCRIPTION
… provided by the requirer

We see some value on providing a way for the requirer to specify the consumer group the client wants to consume from. This should be rather useful and important both in 
1. Migration (as the consumer wants to consume from the same group but on a different cluster. If we can't request a particular consumer group we would need to re-consume the queue from the first offset available in the new cluster)
2. Client password rotation (as we want to connect to an existing consumer group, but being provided different credentials)
