### PR TITLE
docs: split list into project-internal and public interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ To quickly get started, you can copy the `interfaces/__template__` folder to cre
 | Category      | Interface                                                                    |                               Status                                |
 |---------------|:-----------------------------------------------------------------------------|:-------------------------------------------------------------------:|
 | Identity      | [`hydra_endpoints`](interfaces/hydra_endpoints/v0/README.md)                 | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+|               | [`kratos_external_idp`](interfaces/kratos_external_idp/v0/README.md)                                     | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+
 
 
 For a more detailed explanation of statuses and how they should be used, see [the legend](https://github.com/canonical/charm-relation-interfaces/blob/main/LEGEND.md).

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To quickly get started, you can copy the `interfaces/__template__` folder to cre
 
 ## Project-internal Interfaces
 
-### MLOps
+### Charmed Kubeflow
 
 | Category      | Interface                                                                    |                               Status                                |
 |---------------|:-----------------------------------------------------------------------------|:-------------------------------------------------------------------:|

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To contribute an interface specification, open a pull request containing a `READ
 
 To quickly get started, you can copy the `interfaces/__template__` folder to create a basic template.
 
-## Interfaces
+## Public Interfaces
 
 | Category      | Interface                                                                    |                               Status                                |
 |---------------|:-----------------------------------------------------------------------------|:-------------------------------------------------------------------:|
@@ -24,10 +24,19 @@ To quickly get started, you can copy the `interfaces/__template__` folder to cre
 |               | [`ingress_per_unit`](interfaces/ingress_per_unit/v0/README.md)               | ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen) |
 |               | [`prometheus_remote_write`](interfaces/prometheus_remote_write/v0/README.md) | ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen) |
 |               | [`prometheus_scrape`](interfaces/prometheus_scrape/v0/README.md)             | ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen) |
-| Metadata      | [`k8s-service`](interfaces/k8s-service/v0/README.md)                         | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 | Security      | [`tls_certificates/v0`](interfaces/tls_certificates/v0/README.md)            | ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen) |
 |               | [`tls_certificates/v1`](interfaces/tls_certificates/v1/README.md)            | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 | Storage       | [`s3`](interfaces/s3/v0/README.md)                                           | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+
+## Project-internal Interfaces
+
+### MLOps
+
+| Category      | Interface                                                                    |                               Status                                |
+|---------------|:-----------------------------------------------------------------------------|:-------------------------------------------------------------------:|
+| Metadata      | [`k8s-service`](interfaces/k8s-service/v0/README.md)                         | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+
+
 
 For a more detailed explanation of statuses and how they should be used, see [the legend](https://github.com/canonical/charm-relation-interfaces/blob/main/LEGEND.md).
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,12 @@ To quickly get started, you can copy the `interfaces/__template__` folder to cre
 |               | [`kafka_client`](interfaces/kafka_client/v0/README.md)                       | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 |               | [`opensearch_client`](interfaces/opensearch_client/v0/README.md)             | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 |               | [`database_backup`](interfaces/database_backup/v0/README.md)                 | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-| Identity      | [`hydra_endpoints`](interfaces/hydra_endpoints/v0/README.md)                 | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-|               | [`oauth`](interfaces/oauth/v0/README.md)                                     | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+| Identity      | [`oauth`](interfaces/oauth/v0/README.md)                                     | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 | Observability | [`grafana_auth`](interfaces/grafana_auth/v0/README.md)                       | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-|               | [`ingress`](interfaces/ingress/v0/README.md)                                 | ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen) |
-|               | [`ingress_per_unit`](interfaces/ingress_per_unit/v0/README.md)               | ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen) |
 |               | [`prometheus_remote_write`](interfaces/prometheus_remote_write/v0/README.md) | ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen) |
 |               | [`prometheus_scrape`](interfaces/prometheus_scrape/v0/README.md)             | ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen) |
+| Networking    | [`ingress`](interfaces/ingress/v0/README.md)                                 | ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen) |
+|               | [`ingress_per_unit`](interfaces/ingress_per_unit/v0/README.md)               | ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen) |
 | Security      | [`tls_certificates/v0`](interfaces/tls_certificates/v0/README.md)            | ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen) |
 |               | [`tls_certificates/v1`](interfaces/tls_certificates/v1/README.md)            | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 | Storage       | [`s3`](interfaces/s3/v0/README.md)                                           | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
@@ -36,6 +35,11 @@ To quickly get started, you can copy the `interfaces/__template__` folder to cre
 |---------------|:-----------------------------------------------------------------------------|:-------------------------------------------------------------------:|
 | Metadata      | [`k8s-service`](interfaces/k8s-service/v0/README.md)                         | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 
+### Identity
+
+| Category      | Interface                                                                    |                               Status                                |
+|---------------|:-----------------------------------------------------------------------------|:-------------------------------------------------------------------:|
+| Identity      | [`hydra_endpoints`](interfaces/hydra_endpoints/v0/README.md)                 | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 
 
 For a more detailed explanation of statuses and how they should be used, see [the legend](https://github.com/canonical/charm-relation-interfaces/blob/main/LEGEND.md).


### PR DESCRIPTION
As the interface spec library continues to grow, the readme will soon become quite unwieldy to parse and navigate. As suggested by @massigori in a verbal conversation, we suggest to break it into internal and public interfaces. I took the liberty to break the internal interface list up on a per project basis.

- @massigori: Should `hydra_endpoints` move into internal?
- @delgod: Should `database_backup` move into internal?
- @Lukewh: when this merges, some adjustments **might** be required in the charmhub interfaces page, depending on how the scraping is implemented.