### PR TITLE
Add kratos_endpoints relation interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ To quickly get started, you can copy the `interfaces/__template__` folder to cre
 
 ### Identity
 
-| Category      | Interface                                                                    |                               Status                                |
-|---------------|:-----------------------------------------------------------------------------|:-------------------------------------------------------------------:|
-| Identity      | [`hydra_endpoints`](interfaces/hydra_endpoints/v0/README.md)                 | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-|               | [`kratos_external_idp`](interfaces/kratos_external_idp/v0/README.md)                                     | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+| Category      | Interface                                                            |                               Status                                |
+|---------------|:---------------------------------------------------------------------|:-------------------------------------------------------------------:|
+| Identity      | [`hydra_endpoints`](interfaces/hydra_endpoints/v0/README.md)         | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+|               | [`kratos_external_idp`](interfaces/kratos_external_idp/v0/README.md) | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+|               | [`kratos_endpoints`](interfaces/kratos_endpoints/v0/README.md)       | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 
 
 

--- a/interfaces/kratos_endpoints/v0/README.md
+++ b/interfaces/kratos_endpoints/v0/README.md
@@ -1,0 +1,58 @@
+# `kratos_endpoints`
+
+## Overview
+
+This relation interface describes the expected behavior of charms claiming to be able to provide or consume a kratos endpoint.
+
+## Usage
+
+The interface will provide admin and public endpoints, in case any other charm belonging to the IAM bundle requires them both.
+
+## Direction
+
+The interface will consist of a provider and a requirer. The provider is expected to supply its public and admin endpoints,
+while the requirer will just read the information from the application databag.
+
+```mermaid
+flowchart
+    Requirer ----> Provider
+    Provider -- kratos_admin_endpoint, kratos_public_endpoint --> Requirer
+```
+
+## Behavior
+
+Both the requirer and the provider need to adhere to a certain set of criteria to be considered compatible with the interface:
+
+### Provider
+
+- Is expected to serve admin and public API endpoints 
+- Is expected to write the public and admin URLs to the application databag.
+
+### Requirer
+
+- Is expected to consume the relation data to set up integration with Kratos.
+
+## Relation Data
+
+### Provider
+
+[\[JSON Schema\]](./schemas/provider.json)
+
+
+#### Example
+
+
+```json
+{
+  "application_data": {
+    "admin_endpoint": "admin-endpoint",
+    "public_endpoint": "public-endpoint"
+  }
+}
+```
+
+### Requirer
+
+[\[JSON Schema\]](./schemas/requirer.json)
+
+n/a

--- a/interfaces/kratos_endpoints/v0/charms.yaml
+++ b/interfaces/kratos_endpoints/v0/charms.yaml
@@ -1,0 +1,7 @@
+providers:
+  - name: kratos-operator
+    url: https://github.com/canonical/kratos-operator
+
+consumers:
+  - name: identity-platform-login-ui-operator
+    url: https://github.com/canonical/identity-platform-login-ui-operator

--- a/interfaces/kratos_endpoints/v0/schemas/provider.json
+++ b/interfaces/kratos_endpoints/v0/schemas/provider.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/kratos_endpoints/schemas/provider.json",
+    "title": "`kratos_endpoints` provider schema",
+    "description": "The `kratos_endpoints` root schema comprises the entire provider databag for this interface.",
+    "default": {},
+    "type": "object",
+    "properties": {
+        "application_data": {
+            "type": "object",
+            "properties": {
+                "admin_endpoint": {
+                    "type": "string"
+                },
+                "public_endpoint": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "admin_endpoint",
+                "public_endpoint"
+            ]
+        }
+    },
+    "required": [
+        "application_data"
+    ]
+}


### PR DESCRIPTION
### Description
`identity-platform-login-ui-operator` requires Kratos' public API endpoint, which will usually be exposed through Ingress using `traefik-k8s` charm. This interface is similar to [hydra-endpoints](https://github.com/canonical/charm-relation-interfaces/pull/45).

To summarize this relation, Kratos needs to provide its endpoints to Login UI charm.

### Future work
In future we plan to create an Admin UI charm which will need Kratos' admin endpoint, thus this relation interface provides both admin and public endpoints - we'd like to keep it reusable across different charms in IAM stack.