### PR TITLE
Add nfs_share integration interface

### DIFF
--- a/interfaces/nfs_share/v0/README.md
+++ b/interfaces/nfs_share/v0/README.md
@@ -1,0 +1,86 @@
+# `nfs_share`
+
+## Overview
+
+This integration interface describes the expected behavior of any charm
+claiming to be able to interface with an NFS share provider or consumer.
+
+## Usage
+
+Charmed operators claiming to provide this interface must implement and
+support the [Network File System (NFS)](https://datatracker.ietf.org/doc/html/rfc5661)
+protcol. Providing charmed operators should support exporting NFS share
+endpoints while Requiring charms should support mounting NFS shares. In most cases, 
+communication between Providers and Requirers will be accomplished using the 
+[nfs_interfaces](https://charmhub.io/storage-libs/libraries/nfs_interfaces) library,
+however, charm developers are free to provide alternative libraries such that they
+fulfill the behavioral and schematic requirements described in this document.
+
+## Direction
+
+The `nfs_share` interface implements a provider/requirer pattern. The consumer is a 
+charm that wishes to act as an NFS client with the ability to mount exported NFS shares. 
+The provider is a charm exposing an NFS share endpoint, and does not need to be an NFS 
+server itself. The provider can be a proxy that exports an NFS share endpoint from a 
+non-charmed NFS storage appliance.
+
+```mermaid
+flowchart TD
+    Requirer -- name, allowlist, size --> Provider
+    Provider -- endpoint --> Requirer
+```
+
+## Behavior
+
+The Provider and the Requirer must adhere to a certain set of criteria to be considered
+compatible with the interface.
+
+### Provider
+
+- Is expected to publish an NFS Uniform Resource Locator in its application databag as
+  share endpoint. The endpoint is expected to have the following structure:
+    
+    > `nfs://[ingress hostname/address]:[port number]/[path to NFS share]`
+
+  Port number is not required in the URL as almost all NFS implementations automatically
+  negotiate the port number, packet size, transport protocol, and NFS version to use.
+
+### Requirer
+
+- Is expected to publish a name/alias that can be used as a unique identifier
+  for a requested NFS share in its application databag.
+- Is expected to be able to publish a size, in gigabytes (GB), for how large to make a 
+  requested NFS share in its application databag.
+- Is expected to be able to publish an allowlist of hostnames that should be granted 
+  read/write access to the requested NFS share.
+
+## Relation Data
+
+### Provider
+
+Provider provides its NFS share endpoints. The NFS share endpoints should be placed in the
+__application__ databag.
+
+[\[JSON Schema\]](./schemas/provider.json)
+
+#### Example
+
+```yaml
+application_data: {
+  endpoint: "nfs://10.152.28.100/volumes/polaris-research-data"
+}
+```
+
+### Requirer
+
+[\[JSON Schema\]](./schemas/requirer.json)
+
+#### Example
+
+```yaml
+application-data: {
+  name: "/polaris-research-data",
+  size: "100",
+  allowlist: "192.168.0.15/24,10.152.28.100/24,"
+}
+```

--- a/interfaces/nfs_share/v0/charms.yaml
+++ b/interfaces/nfs_share/v0/charms.yaml
@@ -1,0 +1,7 @@
+providers:
+  - name: nfs-server-proxy-operator
+    url: https://github.com/canonical/nfs-server-proxy-operator
+
+consumers:
+  - name: nfs-client-operator
+    url: https://github.com/canonical/nfs-client-operator

--- a/interfaces/nfs_share/v0/schemas/provider.json
+++ b/interfaces/nfs_share/v0/schemas/provider.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/nfs_share/schemas/provider.json",
+    "type": "object",
+    "title": "`nfs_share` provider schema",
+    "description": "The `nfs_share` root schema comprises the entire provider databag for this interface.",
+    "default": {},
+    "examples": [
+        {
+            "application_data": {
+                "endpoint": "nfs://10.152.28.100/volumes/polaris-research-data"
+            }
+        }
+    ],
+    "required": [
+        "endpoint"
+    ],
+    "properties": {
+        "application-data": {
+            "$id": "#/properties/application-data",
+            "title": "Application Databag",
+            "type": "object",
+            "additionalProperties": true
+        },
+        "properties": {
+            "endpoint": {
+                "type": "string",
+                "title": "NFS share endpoint",
+                "description": "The NFS share provider's NFS share endpoint URL.",
+                "examples": [
+                    "nfs://10.152.28.100/volumes/polaris-research-data"
+                ]
+            }
+        }
+    }
+}

--- a/interfaces/nfs_share/v0/schemas/requirer.json
+++ b/interfaces/nfs_share/v0/schemas/requirer.json
@@ -1,0 +1,54 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/nfs_share/schemas/requirer.json",
+    "type": "object",
+    "title": "`nfs_share` requirer schema",
+    "description": "The `nfs_share` root schema comprises the entire requirer databag for this interface.",
+    "default": {},
+    "examples": [
+        {
+            "application-data": {
+                "name": "/polaris-research-data",
+                "size": "100",
+                "allowlist": "192.168.0.15/24,10.152.28.100/24,"
+            }
+        }
+    ],
+    "required": [
+        "name"
+    ],
+    "properties": {
+        "application-data": {
+            "$id": "#/properties/application-data",
+            "title": "Application Databag",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name/alias of the requested NFS share.",
+                    "examples": [
+                        "/polaris-research-data"
+                    ]
+                },
+                "size": {
+                    "type": "string",
+                    "title": "Size",
+                    "description": "Requested size for NFS share in gigabytes (GB).",
+                    "examples": [
+                        "100"
+                    ]
+                },
+                "allowlist": {
+                    "type": "string",
+                    "title": "Allowlist",
+                    "description": "Comma-separated list of addresses/hostnames to grant access to.",
+                    "examples": [
+                        "192.168.0.15/24,10.152.28.100/24,"
+                    ]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hello there! This pull request aims to add the `nfs_share` integration (I think that's what we're calling relations now) interface for defining integrations between NFS file system providers and consumers. There are currently two charms that implement the `nfs_share` specification published on Charmhub:

* Consumer: https://charmhub.io/nfs-client
* Provider: https://charmhub.io/nfs-server-proxy

There is also a published charm library that implements this integration specification:

* `nfs_interfaces`: https://charmhub.io/storage-libs/libraries/nfs_interfaces

Let me know if I am missing anything or if there are any questions!