### PR TITLE
discover ci step

### DIFF
--- a/.github/workflows/discover.yaml
+++ b/.github/workflows/discover.yaml
@@ -23,8 +23,7 @@ jobs:
         with:
           python-version: 3.8
       - name: install interface-tester
-        # todo: pin to pypi package when available
         run: |
-          python -m pip install git+https://github.com/canonical/interface-tester-pytest
+          python -m pip install pytest-interface-tester
       - name: run discover
         uses: interface_tester discover --include ${{ inputs.interface-name }}

--- a/.github/workflows/discover.yaml
+++ b/.github/workflows/discover.yaml
@@ -1,6 +1,13 @@
 name: Discover interfaces
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      interface-name:
+        type: string
+        default: "*"
+        required: true
+        description: "Path.glob() argument to select which interface(s) to discover."
 
 jobs:
   main:

--- a/.github/workflows/discover.yaml
+++ b/.github/workflows/discover.yaml
@@ -1,0 +1,23 @@
+name: Discover interfaces
+
+on: workflow_dispatch
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    name: Pretty print, for all interfaces, their schemas and interface tests.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Set up python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: install interface-tester
+        # todo: pin to pypi package when available
+        run: |
+          python -m pip install git+https://github.com/canonical/interface-tester-pytest
+      - name: run discover
+        uses: interface_tester discover

--- a/.github/workflows/discover.yaml
+++ b/.github/workflows/discover.yaml
@@ -27,4 +27,4 @@ jobs:
         run: |
           python -m pip install git+https://github.com/canonical/interface-tester-pytest
       - name: run discover
-        uses: interface_tester discover
+        uses: interface_tester discover --include ${{ inputs.interface-name }}


### PR DESCRIPTION
This PR adds a 'discover' workflow action that allows us to run `interface_tester discover` on, for example, a PR branch.
The idea is that when reviewing e.g. #55 or #59 we can click on a 'Discover' button in the GH UI and see, for example:
```
Discovered:
login_ui_endpoints:
  - v0:
   - requirer:
     - <no tests>
     - schema NOT OK
     - <no charms>
   - provider:
     - <no tests>
     - schema OK
     - charms:
       - identity-platform-login-ui-operator (https://github.com/canonical/identity-platform-login-ui-operator) custom_test_setup=no
```

which tells us that the requirer schema is not correctly implemented and that no interface tests are present.
This makes reviewing PRs somewhat easier; otherwise it's harder to verify that tests being added or schemas being modified are correctly gathered by the same code that will eventually use them.