### PR TITLE
Implementation of the 5G NRF interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,11 @@ To quickly get started, see the [template interface](https://github.com/canonica
 |               | [`kratos_external_idp`](interfaces/kratos_external_idp/v0/README.md) | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 |               | [`kratos_endpoints`](interfaces/kratos_endpoints/v0/README.md)       | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 
+### Telco
+
+| Category   | Interface                                        |                               Status                                |
+|------------|:-------------------------------------------------|:-------------------------------------------------------------------:|
+| Charmed 5G | [`fiveg_nrf`](interfaces/fiveg_nrf/v0/README.md) | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+
 For a more detailed explanation of statuses and how they should be used, see [the legend](https://github.com/canonical/charm-relation-interfaces/blob/main/LEGEND.md).
 

--- a/docs/json_schemas/fiveg_nrf/v0/provider.json
+++ b/docs/json_schemas/fiveg_nrf/v0/provider.json
@@ -1,0 +1,43 @@
+{
+  "title": "ProviderSchema",
+  "description": "Provider schema for fiveg_nrf.",
+  "type": "object",
+  "properties": {
+    "unit": {
+      "$ref": "#/definitions/BaseModel"
+    },
+    "app": {
+      "$ref": "#/definitions/MyProviderAppData"
+    }
+  },
+  "required": [
+    "app"
+  ],
+  "definitions": {
+    "BaseModel": {
+      "title": "BaseModel",
+      "type": "object",
+      "properties": {}
+    },
+    "MyProviderAppData": {
+      "title": "MyProviderAppData",
+      "type": "object",
+      "properties": {
+        "url": {
+          "title": "Url",
+          "description": "url to reach the NRF.",
+          "examples": [
+            "https://nrf-example.com:1234"
+          ],
+          "minLength": 1,
+          "maxLength": 65536,
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "url"
+      ]
+    }
+  }
+}

--- a/docs/json_schemas/fiveg_nrf/v0/requirer.json
+++ b/docs/json_schemas/fiveg_nrf/v0/requirer.json
@@ -1,0 +1,20 @@
+{
+  "title": "RequirerSchema",
+  "description": "Requirer schema for fiveg_nrf.",
+  "type": "object",
+  "properties": {
+    "unit": {
+      "$ref": "#/definitions/BaseModel"
+    },
+    "app": {
+      "$ref": "#/definitions/BaseModel"
+    }
+  },
+  "definitions": {
+    "BaseModel": {
+      "title": "BaseModel",
+      "type": "object",
+      "properties": {}
+    }
+  }
+}

--- a/interfaces/fiveg_nrf/v0/README.md
+++ b/interfaces/fiveg_nrf/v0/README.md
@@ -1,0 +1,43 @@
+# `fiveg_nrf`
+
+## Usage
+
+Within 5G, the Network Repository Function (NRF) is responsible for providing information about discovered network function instances.
+
+This relation interface describes the expected behavior of any charm claiming to be able to provide or consume NRF information.
+
+## Direction
+
+```mermaid
+flowchart TD
+    Provider -- url --> Requirer
+```
+
+As with all Juju relations, the `fiveg_nrf` interface consists of two parties: a Provider and a Requirer.
+
+## Behavior
+
+Both the Requirer and the Provider need to adhere to criteria to be considered compatible with the interface.
+
+### Provider
+
+- Is expected to provide the NRF url.
+
+### Requirer
+
+- Is expected to use the provider's url to register itself and/or learn about registered network functions.
+
+## Relation Data
+
+[\[Pydantic Schema\]](./schema.py)
+
+#### Example
+
+```yaml
+provider:
+  app: {"url": "http://example-nrf.com:1234"}
+  unit: {}
+requirer:
+  app: {}
+  unit: {}
+```

--- a/interfaces/fiveg_nrf/v0/charms.yaml
+++ b/interfaces/fiveg_nrf/v0/charms.yaml
@@ -1,0 +1,2 @@
+providers: []
+requirers: []

--- a/interfaces/fiveg_nrf/v0/schema.py
+++ b/interfaces/fiveg_nrf/v0/schema.py
@@ -1,0 +1,29 @@
+"""This file defines the schemas for the provider and requirer sides of the `fiveg_nrf` interface.
+It exposes two interfaces.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {"url": "http://nrf-example.com:1234"}
+    RequirerSchema:
+        unit: <empty>
+        app:  <empty>
+"""
+
+from pydantic import BaseModel, AnyHttpUrl
+
+from interface_tester.schema_base import DataBagSchema
+
+
+class MyProviderAppData(BaseModel):
+    url: AnyHttpUrl
+
+
+class ProviderSchema(DataBagSchema):
+    """Provider schema for fiveg_nrf."""
+    app: MyProviderAppData
+
+
+class RequirerSchema(DataBagSchema):
+    """Requirer schema for fiveg_nrf."""

--- a/interfaces/fiveg_nrf/v0/schema.py
+++ b/interfaces/fiveg_nrf/v0/schema.py
@@ -5,19 +5,22 @@ It exposes two interfaces.schema_base.DataBagSchema subclasses called:
 Examples:
     ProviderSchema:
         unit: <empty>
-        app: {"url": "http://nrf-example.com:1234"}
+        app: {"url": "https://nrf-example.com:1234"}
     RequirerSchema:
         unit: <empty>
         app:  <empty>
 """
 
-from pydantic import BaseModel, AnyHttpUrl
+from pydantic import BaseModel, AnyHttpUrl, Field
 
 from interface_tester.schema_base import DataBagSchema
 
 
 class MyProviderAppData(BaseModel):
-    url: AnyHttpUrl
+    url: AnyHttpUrl = Field(
+        description="url to reach the NRF.",
+        examples=["https://nrf-example.com:1234"]
+    )
 
 
 class ProviderSchema(DataBagSchema):


### PR DESCRIPTION
### Overview
Within 5G, the Network Repository Function (NRF) is responsible for providing information about discovered network function instances. This relation interface describes the expected behavior of any charm claiming to be able to provide or consume NRF information.

### References
- https://www.iplook.com/products/5gc-nrf#:~:text=NRF%2C%20one%20of%20the%20network,discovered)%20to%20another%20NF%20instance.
- https://docs.google.com/document/d/1GDDrwXhICAK0ttBCMYlnZ6TEc2QSnxcR_jKMxMr59pE/edit