### PR TITLE
Add enabled-plugins field to postgresql_client provider

### DIFF
--- a/interfaces/postgresql_client/v0/README.md
+++ b/interfaces/postgresql_client/v0/README.md
@@ -26,6 +26,7 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
 - Is expected to provide `username` and `password` fields when Requirer provides the `database` field.
 - Is expected to provide the `endpoints` field with has address of Primary, which can be used for Read/Write queries.
 - Is expected to provide the `database` field with the database that was actually created.
+- Is expected to provide optional `enabled-plugins` field with a comma-separated list of plugins that are currently enabled in the database.
 - Is expected to provide optional `read-only-endpoints` field with a comma-separated list of hosts or one Kubernetes Service, which can be used for Read-only queries.
 - Is expected to provide the `version` field whenever database charm wants to communicate its database version.
 
@@ -55,6 +56,7 @@ Provider provides credentials, endpoints, TLS info and database-specific fields.
     related-endpoint: database
     application-data:
       database: myappB
+      enabled-plugins: citext,hstore,pgtrgm,unaccent 
       endpoints: postgresql-k8s-primary:5432
       read-only-endpoints: postgresql-k8s-replicas:5432
       password: Dy0k2UTfyNt2B13cfe412K7YGs07S4U7

--- a/interfaces/postgresql_client/v0/schemas/provider.json
+++ b/interfaces/postgresql_client/v0/schemas/provider.json
@@ -43,6 +43,16 @@
                 "myapp"
             ]
         },
+        "enabled-plugins": {
+            "$id": "#/properties/enabled-plugins",
+            "title": "Enabled plugins in the database",
+            "description": "A list of plugins that are enabled in the database.",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "plugin-1,plugin-2"
+            ]
+        },
         "endpoints": {
             "$id": "#/properties/endpoints",
             "title": "Database Endpoints",
@@ -78,6 +88,7 @@
         "username": "relation-14",
         "password": "alphanum-32byte-random",
         "database": "myapp",
+        "enabled-plugins": "plugin-1,plugin-2",
         "endpoints": "unit-1:port,unit-2:port",
         "read-only-endpoints": "unit-1:port,unit-2:port",
         "version": "8.0.27-18"


### PR DESCRIPTION
This PR consists of adding a new field called `enabled-plugins`, initially only, to the `postgresql_client` provider.

This should enable client application charms to know when on plugin is not available/enabled in the database and set a blocked status to make the user aware of that.

The new field should be handled in the requirer side through a function called `is_plugin_enabled` on [data_interfaces library](https://charmhub.io/data-platform-libs/libraries/data_interfaces), to make it easy for charms to consume it.

More details on the item number 3 from [DPE-1372](https://warthogs.atlassian.net/browse/DPE-1372).

[DPE-1372]: https://warthogs.atlassian.net/browse/DPE-1372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ