### PR TITLE
Adds information about the fiveg_n3 interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 dist/
 .ruff_cache
 .pytest_cache
+.idea/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ To quickly get started, see the [template interface](https://github.com/canonica
 | Category   | Interface                                        |                               Status                                |
 |------------|:-------------------------------------------------|:-------------------------------------------------------------------:|
 | Charmed 5G | [`fiveg_nrf`](interfaces/fiveg_nrf/v0/README.md) | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+| Charmed 5G | [`fiveg_n3`](interfaces/fiveg_n3/v0/README.md)   | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 
 For a more detailed explanation of statuses and how they should be used, see [the legend](https://github.com/canonical/charm-relation-interfaces/blob/main/LEGEND.md).
 

--- a/docs/json_schemas/fiveg_n3/v0/provider.json
+++ b/docs/json_schemas/fiveg_n3/v0/provider.json
@@ -1,0 +1,36 @@
+{
+  "title": "ProviderSchema",
+  "description": "Provider schema for fiveg_n3",
+  "type": "object",
+  "properties": {
+    "unit": {
+      "$ref": "#/definitions/BaseModel"
+    },
+    "app": {
+      "$ref": "#/definitions/FivegN#ProviderAppData"
+    }
+  },
+  "required": [
+    "app"
+  ],
+  "definitions": {
+    "BaseModel": {
+      "title": "BaseModel",
+      "type": "object",
+      "properties": {}
+    },
+    "FivegN3ProviderAppData": {
+      "title": "FivegN3ProviderAppData",
+      "type": "object",
+      "properties": {
+        "upf_ipaddress": {
+          "title": "UPF IP Address",
+          "type": "string"
+        }
+      },
+      "required": [
+        "upf_ipaddress"
+      ]
+    }
+  }
+}

--- a/docs/json_schemas/fiveg_n3/v0/requirer.json
+++ b/docs/json_schemas/fiveg_n3/v0/requirer.json
@@ -1,0 +1,20 @@
+{
+  "title": "RequirerSchema",
+  "description": "Requirer schema for fiveg_n3",
+  "type": "object",
+  "properties": {
+    "unit": {
+      "$ref": "#/definitions/BaseModel"
+    },
+    "app": {
+      "$ref": "#/definitions/BaseModel"
+    }
+  },
+  "definitions": {
+    "BaseModel": {
+      "title": "BaseModel",
+      "type": "object",
+      "properties": {}
+    }
+  }
+}

--- a/interfaces/fiveg_n3/v0/README.md
+++ b/interfaces/fiveg_n3/v0/README.md
@@ -1,0 +1,48 @@
+# `fiveg_n3`
+
+## Usage
+
+Within 5G, the User Plane Function (UPF) supports features and capabilities to facilitate 
+user plane operation. Examples include: packet routing and forwarding, interconnection 
+to the Data Network, policy enforcement and data buffering.
+
+This relation interface describes the expected behavior of any charm claiming to be able to provide 
+or consume the UPF information in order to establish communication over the N3 interface.
+
+## Direction
+
+```mermaid
+flowchart TD
+    Provider -- IP address --> Requirer
+```
+
+As with all Juju relations, the `fiveg_n3` interface consists of two parties: a Provider 
+and a Requirer.
+
+## Behavior
+
+Both the Requirer and the Provider need to adhere to criteria to be considered compatible 
+with the interface.
+
+### Provider
+
+- Is expected to provide the UPF IP address.
+
+### Requirer
+
+- Is expected to use the UPF IP address to establish communication over the N3 interface.
+
+## Relation Data
+
+[\[Pydantic Schema\]](./schema.py)
+
+#### Example
+
+```yaml
+provider:
+  app: {"upf_ipaddress": "1.2.3.4"}
+  unit: {}
+requirer:
+  app: {}
+  unit: {}
+```

--- a/interfaces/fiveg_n3/v0/charms.yaml
+++ b/interfaces/fiveg_n3/v0/charms.yaml
@@ -1,0 +1,2 @@
+providers: []
+requirers: []

--- a/interfaces/fiveg_n3/v0/schema.py
+++ b/interfaces/fiveg_n3/v0/schema.py
@@ -1,0 +1,31 @@
+"""This file defines the schemas for the provider and requirer sides of the `fiveg_n3` interface.
+It exposes two interfaces.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {
+            "upf_ipaddress": "1.2.3.4"
+        }
+    RequirerSchema:
+        unit: <empty>
+        app:  <empty>
+"""
+
+from pydantic import BaseModel
+
+from interface_tester.schema_base import DataBagSchema
+
+
+class FivegN3ProviderAppData(BaseModel):
+    upf_ipaddress: str
+
+
+class ProviderSchema(DataBagSchema):
+    """Provider schema for fiveg_n2."""
+    app: FivegN3ProviderAppData
+
+
+class RequirerSchema(DataBagSchema):
+    """Requirer schema for fiveg_n3."""


### PR DESCRIPTION
**Overview**:
The 5G radio (gNodeB) requires to know the address of the UPF in order to communicate with the core’s user plane. A new charm relation interface should be defined, created and used for charms providing/requiring connectivity to the N3 user plane.

**Reference**:
https://docs.google.com/document/d/1GDDrwXhICAK0ttBCMYlnZ6TEc2QSnxcR_jKMxMr59pE/edit#