### PR TITLE
Implementation of the `ip_router` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,28 +17,28 @@ To quickly get started, see the [template interface](https://github.com/canonica
 
 ## Interfaces
 
-| Category      | Interface                                                                    |                                 Status                                  |
-|---------------|:-----------------------------------------------------------------------------|:-----------------------------------------------------------------------:|
-| Data          | [`mysql_client`](interfaces/mysql_client/v0/README.md)                       |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
-|               | [`postgresql_client`](interfaces/postgresql_client/v0/README.md)             |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
-|               | [`mongodb_client`](interfaces/mongodb_client/v0/README.md)                   |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
-|               | [`kafka_client`](interfaces/kafka_client/v0/README.md)                       |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
-|               | [`opensearch_client`](interfaces/opensearch_client/v0/README.md)             |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
-|               | [`database_backup`](interfaces/database_backup/v0/README.md)                 |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
-| Identity      | [`hydra_endpoints`](interfaces/hydra_endpoints/v0/README.md)                 |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
-|               | [`oauth`](interfaces/oauth/v0/README.md)                                     |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
-| Observability | [`grafana_auth`](interfaces/grafana_auth/v0/README.md)                       |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
-|               | [`prometheus_remote_write`](interfaces/prometheus_remote_write/v0/README.md) |   ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen)   |
-|               | [`prometheus_scrape`](interfaces/prometheus_scrape/v0/README.md)             |   ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen)   |
-| Networking    | [`ingress`](interfaces/ingress/v1/README.md)                                 |   ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen)   |
-|               | [`ingress_per_unit`](interfaces/ingress_per_unit/v0/README.md)               |   ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen)   |
-|               | [`nginx_route`](interfaces/nginx_route/v0/README.md)                         |  ![Status: Draft](https://img.shields.io/badge/Status-Draft-darkgreen)  |
-|               | [`router`](interfaces/router/v0/README.md)                                   | ![Status: Draft](https://img.shields.io/badge/Status-Draft-darkgreen)   |
-| Security      | [`mutual_tls`](interfaces/mutual_tls/v0/README.md)                           |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
-|               | [`tls_certificates/v0`](interfaces/tls_certificates/v0/README.md)            |   ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen)   |
-|               | [`tls_certificates/v1`](interfaces/tls_certificates/v1/README.md)            |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
-| Metadata      | [`k8s-service`](interfaces/k8s-service/v0/README.md)                         |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
-| Storage       | [`s3`](interfaces/s3/v0/README.md)                                           |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
+| Category      | Interface                                                                    |                                Status                                 |
+|---------------|:-----------------------------------------------------------------------------|:---------------------------------------------------------------------:|
+| Data          | [`mysql_client`](interfaces/mysql_client/v0/README.md)                       |  ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)   |
+|               | [`postgresql_client`](interfaces/postgresql_client/v0/README.md)             |  ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)   |
+|               | [`mongodb_client`](interfaces/mongodb_client/v0/README.md)                   |  ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)   |
+|               | [`kafka_client`](interfaces/kafka_client/v0/README.md)                       |  ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)   |
+|               | [`opensearch_client`](interfaces/opensearch_client/v0/README.md)             |  ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)   |
+|               | [`database_backup`](interfaces/database_backup/v0/README.md)                 |  ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)   |
+| Identity      | [`hydra_endpoints`](interfaces/hydra_endpoints/v0/README.md)                 |  ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)   |
+|               | [`oauth`](interfaces/oauth/v0/README.md)                                     |  ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)   |
+| Observability | [`grafana_auth`](interfaces/grafana_auth/v0/README.md)                       |  ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)   |
+|               | [`prometheus_remote_write`](interfaces/prometheus_remote_write/v0/README.md) |  ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen)  |
+|               | [`prometheus_scrape`](interfaces/prometheus_scrape/v0/README.md)             |  ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen)  |
+| Networking    | [`ingress`](interfaces/ingress/v1/README.md)                                 |  ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen)  |
+|               | [`ingress_per_unit`](interfaces/ingress_per_unit/v0/README.md)               |  ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen)  |
+|               | [`nginx_route`](interfaces/nginx_route/v0/README.md)                         | ![Status: Draft](https://img.shields.io/badge/Status-Draft-darkgreen) |
+|               | [`ip_router`](interfaces/ip_router/v0/README.md)                             | ![Status: Draft](https://img.shields.io/badge/Status-Draft-darkgreen) |
+| Security      | [`mutual_tls`](interfaces/mutual_tls/v0/README.md)                           |  ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)   |
+|               | [`tls_certificates/v0`](interfaces/tls_certificates/v0/README.md)            |  ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen)  |
+|               | [`tls_certificates/v1`](interfaces/tls_certificates/v1/README.md)            |  ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)   |
+| Metadata      | [`k8s-service`](interfaces/k8s-service/v0/README.md)                         |  ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)   |
+| Storage       | [`s3`](interfaces/s3/v0/README.md)                                           |  ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)   |
 
 ## Project-internal Interfaces
 

--- a/README.md
+++ b/README.md
@@ -17,27 +17,28 @@ To quickly get started, see the [template interface](https://github.com/canonica
 
 ## Interfaces
 
-| Category      | Interface                                                                    |                               Status                                |
-|---------------|:-----------------------------------------------------------------------------|:-------------------------------------------------------------------:|
-| Data          | [`mysql_client`](interfaces/mysql_client/v0/README.md)                       | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-|               | [`postgresql_client`](interfaces/postgresql_client/v0/README.md)             | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-|               | [`mongodb_client`](interfaces/mongodb_client/v0/README.md)                   | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-|               | [`kafka_client`](interfaces/kafka_client/v0/README.md)                       | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-|               | [`opensearch_client`](interfaces/opensearch_client/v0/README.md)             | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-|               | [`database_backup`](interfaces/database_backup/v0/README.md)                 | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-| Identity      | [`hydra_endpoints`](interfaces/hydra_endpoints/v0/README.md)                 | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-|               | [`oauth`](interfaces/oauth/v0/README.md)                                     | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-| Observability | [`grafana_auth`](interfaces/grafana_auth/v0/README.md)                       | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-|               | [`prometheus_remote_write`](interfaces/prometheus_remote_write/v0/README.md) | ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen) |
-|               | [`prometheus_scrape`](interfaces/prometheus_scrape/v0/README.md)             | ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen) |
-| Networking    | [`ingress`](interfaces/ingress/v1/README.md)                                 | ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen) |
-|               | [`ingress_per_unit`](interfaces/ingress_per_unit/v0/README.md)               | ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen) |
-|               | [`nginx_route`](interfaces/nginx_route/v0/README.md)                         | ![Status: Draft](https://img.shields.io/badge/Status-Draft-darkgreen) |
-| Security      | [`mutual_tls`](interfaces/mutual_tls/v0/README.md)                           | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-|               | [`tls_certificates/v0`](interfaces/tls_certificates/v0/README.md)            | ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen) |
-|               | [`tls_certificates/v1`](interfaces/tls_certificates/v1/README.md)            | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-| Metadata      | [`k8s-service`](interfaces/k8s-service/v0/README.md)                         | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-| Storage       | [`s3`](interfaces/s3/v0/README.md)                                           | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+| Category      | Interface                                                                    |                                 Status                                  |
+|---------------|:-----------------------------------------------------------------------------|:-----------------------------------------------------------------------:|
+| Data          | [`mysql_client`](interfaces/mysql_client/v0/README.md)                       |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
+|               | [`postgresql_client`](interfaces/postgresql_client/v0/README.md)             |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
+|               | [`mongodb_client`](interfaces/mongodb_client/v0/README.md)                   |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
+|               | [`kafka_client`](interfaces/kafka_client/v0/README.md)                       |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
+|               | [`opensearch_client`](interfaces/opensearch_client/v0/README.md)             |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
+|               | [`database_backup`](interfaces/database_backup/v0/README.md)                 |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
+| Identity      | [`hydra_endpoints`](interfaces/hydra_endpoints/v0/README.md)                 |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
+|               | [`oauth`](interfaces/oauth/v0/README.md)                                     |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
+| Observability | [`grafana_auth`](interfaces/grafana_auth/v0/README.md)                       |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
+|               | [`prometheus_remote_write`](interfaces/prometheus_remote_write/v0/README.md) |   ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen)   |
+|               | [`prometheus_scrape`](interfaces/prometheus_scrape/v0/README.md)             |   ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen)   |
+| Networking    | [`ingress`](interfaces/ingress/v1/README.md)                                 |   ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen)   |
+|               | [`ingress_per_unit`](interfaces/ingress_per_unit/v0/README.md)               |   ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen)   |
+|               | [`nginx_route`](interfaces/nginx_route/v0/README.md)                         |  ![Status: Draft](https://img.shields.io/badge/Status-Draft-darkgreen)  |
+|               | [`router`](interfaces/router/v0/README.md)                                   | ![Status: Draft](https://img.shields.io/badge/Status-Draft-darkgreen)   |
+| Security      | [`mutual_tls`](interfaces/mutual_tls/v0/README.md)                           |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
+|               | [`tls_certificates/v0`](interfaces/tls_certificates/v0/README.md)            |   ![Status: Live](https://img.shields.io/badge/Status-Live-darkgreen)   |
+|               | [`tls_certificates/v1`](interfaces/tls_certificates/v1/README.md)            |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
+| Metadata      | [`k8s-service`](interfaces/k8s-service/v0/README.md)                         |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
+| Storage       | [`s3`](interfaces/s3/v0/README.md)                                           |   ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)    |
 
 ## Project-internal Interfaces
 

--- a/docs/json_schemas/ip_router/v0/provider.json
+++ b/docs/json_schemas/ip_router/v0/provider.json
@@ -1,0 +1,86 @@
+{
+  "title": "ProviderSchema",
+  "description": "Provider schema for ip_router.",
+  "type": "object",
+  "properties": {
+    "unit": {
+      "$ref": "#/definitions/BaseModel"
+    },
+    "app": {
+      "$ref": "#/definitions/IPRouterProviderAppData"
+    }
+  },
+  "required": [
+    "app"
+  ],
+  "definitions": {
+    "BaseModel": {
+      "title": "BaseModel",
+      "type": "object",
+      "properties": {}
+    },
+    "Route": {
+      "title": "Route",
+      "type": "object",
+      "properties": {
+        "destination": {
+          "title": "Destination",
+          "type": "string",
+          "format": "ipvanyaddress"
+        },
+        "gateway": {
+          "title": "Gateway",
+          "type": "string",
+          "format": "ipvanyaddress"
+        }
+      },
+      "required": [
+        "destination",
+        "gateway"
+      ]
+    },
+    "IPNetwork": {
+      "title": "IPNetwork",
+      "type": "object",
+      "properties": {
+        "network": {
+          "title": "Network",
+          "type": "string",
+          "format": "ipvanynetwork"
+        },
+        "gateway": {
+          "title": "Gateway",
+          "type": "string",
+          "format": "ipvanyaddress"
+        },
+        "routes": {
+          "title": "Routes",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Route"
+          }
+        }
+      },
+      "required": [
+        "network",
+        "gateway"
+      ]
+    },
+    "IPRouterProviderAppData": {
+      "title": "IPRouterProviderAppData",
+      "type": "object",
+      "properties": {
+        "networks": {
+          "title": "Networks",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IPNetwork"
+          }
+        }
+      },
+      "required": [
+        "networks"
+      ]
+    }
+  }
+}

--- a/docs/json_schemas/ip_router/v0/requirer.json
+++ b/docs/json_schemas/ip_router/v0/requirer.json
@@ -1,0 +1,86 @@
+{
+  "title": "RequirerSchema",
+  "description": "Requirer schema for ip_router.",
+  "type": "object",
+  "properties": {
+    "unit": {
+      "$ref": "#/definitions/BaseModel"
+    },
+    "app": {
+      "$ref": "#/definitions/IPRouterRequirerAppData"
+    }
+  },
+  "required": [
+    "app"
+  ],
+  "definitions": {
+    "BaseModel": {
+      "title": "BaseModel",
+      "type": "object",
+      "properties": {}
+    },
+    "Route": {
+      "title": "Route",
+      "type": "object",
+      "properties": {
+        "destination": {
+          "title": "Destination",
+          "type": "string",
+          "format": "ipvanyaddress"
+        },
+        "gateway": {
+          "title": "Gateway",
+          "type": "string",
+          "format": "ipvanyaddress"
+        }
+      },
+      "required": [
+        "destination",
+        "gateway"
+      ]
+    },
+    "IPNetwork": {
+      "title": "IPNetwork",
+      "type": "object",
+      "properties": {
+        "network": {
+          "title": "Network",
+          "type": "string",
+          "format": "ipvanynetwork"
+        },
+        "gateway": {
+          "title": "Gateway",
+          "type": "string",
+          "format": "ipvanyaddress"
+        },
+        "routes": {
+          "title": "Routes",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Route"
+          }
+        }
+      },
+      "required": [
+        "network",
+        "gateway"
+      ]
+    },
+    "IPRouterRequirerAppData": {
+      "title": "IPRouterRequirerAppData",
+      "type": "object",
+      "properties": {
+        "networks": {
+          "title": "Networks",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IPNetwork"
+          }
+        }
+      },
+      "required": [
+        "networks"
+      ]
+    }
+  }
+}

--- a/interfaces/ip_router/v0/README.md
+++ b/interfaces/ip_router/v0/README.md
@@ -1,0 +1,79 @@
+# `ip_router`
+
+## Usage
+
+The `ip_router` relation interface describes the expected behavior of any charm claiming to be able 
+to provide or consume IP routes.
+
+## Direction
+
+```mermaid
+flowchart TD
+    Requirer -- Networks --> Provider
+    Provider -- Networks --> Requirer
+```
+
+As with all Juju relations, the `ip_router` interface consists of two parties: a Provider and a Requirer.
+
+## Behavior
+
+Both the Requirer and the Provider need to adhere to criteria to be considered compatible with the interface.
+
+### Requirer
+
+- Is expected to provide a list of networks, each containing a gateway and routes
+
+### Provider
+
+- Is expected to have an interface available at the gateway address provided by the requirer
+- Is expected to implement the requested routes provided by the requirer
+- Is expected to provide the list of networks it contains
+
+## Relation Data
+
+[\[Pydantic Schema\]](./schema.py)
+
+#### Example
+
+```yaml
+requirer:
+  app: {
+    "networks": [
+      {
+        "network": "192.168.250.0/24",
+        "gateway": "192.168.250.1",
+        "routes": [
+          {
+            "destination": "172.250.0.0/16",
+            "gateway": "192.168.250.3"
+          }
+        ]
+      }
+    ]
+  }
+  unit: { }
+provider:
+  app: {
+    "networks": [
+      {
+        "network": "192.168.250.0/24",
+        "gateway": "192.168.250.1",
+        "routes": [
+          {
+            "destination": "172.250.0.0/16",
+            "gateway": "192.168.250.3"
+          }
+        ]
+      },
+      {
+        "network": "192.168.252.0/24",
+        "gateway": "192.168.252.1",
+      },
+      {
+        "network": "192.168.251.0/24",
+        "gateway": "192.168.251.1/24"
+      }
+    ]
+  }
+  unit: { }
+```

--- a/interfaces/ip_router/v0/charms.yaml
+++ b/interfaces/ip_router/v0/charms.yaml
@@ -1,0 +1,2 @@
+providers: []
+requirers: []

--- a/interfaces/ip_router/v0/schema.py
+++ b/interfaces/ip_router/v0/schema.py
@@ -47,7 +47,7 @@ Examples:
 """
 
 from pydantic import BaseModel, IPvAnyAddress, IPvAnyNetwork
-from typing import Optional
+from typing import Optional, List
 from interface_tester.schema_base import DataBagSchema
 
 
@@ -59,15 +59,15 @@ class Route(BaseModel):
 class IPNetwork(BaseModel):
     network: IPvAnyNetwork
     gateway: IPvAnyAddress
-    routes: Optional[list[Route]]
+    routes: Optional[List[Route]]
 
 
 class IPRouterProviderAppData(BaseModel):
-    networks: list[IPNetwork]
+    networks: List[IPNetwork]
 
 
 class IPRouterRequirerAppData(BaseModel):
-    networks: list[IPNetwork]
+    networks: List[IPNetwork]
 
 
 class ProviderSchema(DataBagSchema):

--- a/interfaces/ip_router/v0/schema.py
+++ b/interfaces/ip_router/v0/schema.py
@@ -1,0 +1,80 @@
+"""This file defines the schemas for the provider and requirer sides of the `ip_router` interface.
+It exposes two interfaces.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {
+              "networks": [
+                {
+                  "network": "192.168.250.0/24",
+                  "gateway": "192.168.250.1",
+                  "routes": [
+                    {
+                      "destination": "172.250.0.0/16",
+                      "gateway": "192.168.250.3"
+                    }
+                  ]
+                },
+                {
+                  "network": "192.168.252.0/24",
+                  "gateway": "192.168.252.1",
+
+                },
+                {
+                  "network": "192.168.251.0/24",
+                  "gateway": "192.168.251.1/24"
+                }
+              ]
+            }
+    RequirerSchema:
+        unit: <empty>
+        app:  {
+              "networks": [
+                {
+                  "network": "192.168.250.0/24",
+                  "gateway": "192.168.250.1",
+                  "routes": [
+                    {
+                      "destination": "172.250.0.0/16",
+                      "gateway": "192.168.250.3"
+                    }
+                  ]
+                }
+              ]
+            }
+"""
+
+from pydantic import BaseModel, IPvAnyAddress, IPvAnyNetwork
+from typing import Optional
+from interface_tester.schema_base import DataBagSchema
+
+
+class Route(BaseModel):
+    destination: IPvAnyAddress
+    gateway: IPvAnyAddress
+
+
+class IPNetwork(BaseModel):
+    network: IPvAnyNetwork
+    gateway: IPvAnyAddress
+    routes: Optional[list[Route]]
+
+
+class IPRouterProviderAppData(BaseModel):
+    networks: list[IPNetwork]
+
+
+class IPRouterRequirerAppData(BaseModel):
+    networks: list[IPNetwork]
+
+
+class ProviderSchema(DataBagSchema):
+    """Provider schema for ip_router."""
+    app: IPRouterProviderAppData
+
+
+class RequirerSchema(DataBagSchema):
+    """Requirer schema for ip_router."""
+    app: IPRouterRequirerAppData


### PR DESCRIPTION
## Overview

This PR includes the implementation of the IP router interface. This interface will be used by charms providing and requiring IP routing. The first use case is withing SD-Core where users will need to specify 3 different networks and have charms with multiple network interfaces on those networks (using Multus). For more information about this use case, you can read [this specification](https://docs.google.com/document/d/1nJBEfPw-k9YDWpqV-qrhZnfsJXyrnrjS-Q2SNnhdPrY/edit).