### PR TITLE
flip tracing relation directionality

### DIFF
--- a/docs/json_schemas/tracing/v0/provider.json
+++ b/docs/json_schemas/tracing/v0/provider.json
@@ -7,14 +7,66 @@
       "$ref": "#/definitions/BaseModel"
     },
     "app": {
-      "$ref": "#/definitions/BaseModel"
+      "$ref": "#/definitions/TracingProviderData"
     }
   },
+  "required": [
+    "app"
+  ],
   "definitions": {
     "BaseModel": {
       "title": "BaseModel",
       "type": "object",
       "properties": {}
+    },
+    "IngesterProtocol": {
+      "title": "IngesterProtocol",
+      "description": "An enumeration.",
+      "enum": [
+        "otlp_grpc",
+        "otlp_http",
+        "zipkin",
+        "tempo"
+      ],
+      "type": "string"
+    },
+    "Ingester": {
+      "title": "Ingester",
+      "type": "object",
+      "properties": {
+        "port": {
+          "title": "Port",
+          "type": "string"
+        },
+        "protocol": {
+          "$ref": "#/definitions/IngesterProtocol"
+        }
+      },
+      "required": [
+        "port",
+        "protocol"
+      ]
+    },
+    "TracingProviderData": {
+      "title": "TracingProviderData",
+      "type": "object",
+      "properties": {
+        "url": {
+          "title": "Url",
+          "type": "string"
+        },
+        "ingesters": {
+          "title": "Ingesters",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Ingester"
+          }
+        }
+      },
+      "required": [
+        "url",
+        "ingesters"
+      ]
     }
   }
 }

--- a/docs/json_schemas/tracing/v0/requirer.json
+++ b/docs/json_schemas/tracing/v0/requirer.json
@@ -7,66 +7,14 @@
       "$ref": "#/definitions/BaseModel"
     },
     "app": {
-      "$ref": "#/definitions/TracingRequirerData"
+      "$ref": "#/definitions/BaseModel"
     }
   },
-  "required": [
-    "app"
-  ],
   "definitions": {
     "BaseModel": {
       "title": "BaseModel",
       "type": "object",
       "properties": {}
-    },
-    "IngesterProtocol": {
-      "title": "IngesterProtocol",
-      "description": "An enumeration.",
-      "enum": [
-        "otlp_grpc",
-        "otlp_http",
-        "zipkin",
-        "tempo"
-      ],
-      "type": "string"
-    },
-    "Ingester": {
-      "title": "Ingester",
-      "type": "object",
-      "properties": {
-        "port": {
-          "title": "Port",
-          "type": "string"
-        },
-        "protocol": {
-          "$ref": "#/definitions/IngesterProtocol"
-        }
-      },
-      "required": [
-        "port",
-        "protocol"
-      ]
-    },
-    "TracingRequirerData": {
-      "title": "TracingRequirerData",
-      "type": "object",
-      "properties": {
-        "url": {
-          "title": "Url",
-          "type": "string"
-        },
-        "ingesters": {
-          "title": "Ingesters",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Ingester"
-          }
-        }
-      },
-      "required": [
-        "url",
-        "ingesters"
-      ]
     }
   }
 }

--- a/interfaces/tracing/v0/README.md
+++ b/interfaces/tracing/v0/README.md
@@ -6,25 +6,25 @@ This relation interface describes the expected behavior of any charm claiming to
 
 ## Direction
 
-Tracing is done in a push-based fashion. 
+Tracing is done in a push-based fashion.
 The receiving endpoint of the tracing backend, also referred to as an ingester, can support a number of different protocols, such as [otlp-grpc](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#otlpgrpc) and [otlp-http](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#otlphttp).
 The tracing backend exposes, for each protocol it supports, an endpoint at which the server is ready to accept that protocol. 
-So the directionality of the relation flows from the observed, the application producing the traces, to the observer (aka the trace ingester, that is, a Tempo(-compliant) backend).
+The directionality of the relation flows from the observer, Tempo(-compliant) backend, to the observed: the application producing the traces.
 
 We call the data structure that is exchanged via this interface the 'TracingBackend'.
 
 ```mermaid
 graph LR
-    Requirer["Ingester (requirer)"]  --> TracingBackend["TracingBackend"] --> Provider["Observed app (provider)"]
+    Provider["Ingester (provider)"]  --> TracingBackend["TracingBackend"] --> Requirer["Observed app (requirer)"]
 ```
 
 ## Behavior
-### Provider
+### Requirer
 
 - Is expected to push traces to one or more of the supported endpoints.
 - Is expected to handle cases where none of the protocols offered by the provider is supported. 
 
-### Requirer
+### Provider
 
 - Is expected to publish the url at which the server is reachable.
 - Is expected to run a server supporting one or more tracing protocols such as [OTLP](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#opentelemetry-protocol-specification).
@@ -32,9 +32,9 @@ graph LR
 
 
 ## Relation Data
-### Requirer
+### Provider
 
-The requirer exposes via its application databag a single `url`, at which the server is reachable, and a list of `ingesters` = ports and protocols.
+The provider exposes via its application databag a single `url`, at which the server is reachable, and a list of `ingesters` = ports and protocols.
 Each ingester port supports a certain tracing protocol, such as OTLP_GRPC or Jaeger. 
 The full list of supported trace protocols can change, but those supported by Tempo at the time of writing are:
 
@@ -59,6 +59,6 @@ application_data:
       port: 5678
 ```
 
-### Provider
+### Requirer
 
-The provider side is not expected to publish any data via this relation's databags.
+The requirer side is not expected to publish any data via this relation's databags.

--- a/interfaces/tracing/v0/interface_tests/requirer_tests.py
+++ b/interfaces/tracing/v0/interface_tests/requirer_tests.py
@@ -8,7 +8,7 @@ from scenario import State, Relation
 
 @interface_test_case(
     event='tracing-relation-created',
-    role='requirer',
+    role='provider',
     schema=SchemaConfig.empty
 )
 def test_no_data_on_created(output_state: State):
@@ -17,7 +17,7 @@ def test_no_data_on_created(output_state: State):
 
 @interface_test_case(
     event='tracing-relation-joined',
-    role='requirer',
+    role='provider',
     schema=SchemaConfig.empty
 )
 def test_no_data_on_joined(output_state: State):
@@ -26,7 +26,7 @@ def test_no_data_on_joined(output_state: State):
 
 @interface_test_case(
     event='tracing-relation-changed',
-    role='requirer',
+    role='provider',
     input_state=State(
         relations=[Relation(
             endpoint='tracing',

--- a/interfaces/tracing/v0/schema.py
+++ b/interfaces/tracing/v0/schema.py
@@ -40,15 +40,15 @@ class Ingester(BaseModel):
     protocol: IngesterProtocol
 
 
-class TracingRequirerData(BaseModel):
+class TracingProviderData(BaseModel):
     url: str
     ingesters: Json[List[Ingester]]
 
 
-class RequirerSchema(DataBagSchema):
-    """Requirer schema for Tracing."""
-    app: TracingRequirerData
-
-
 class ProviderSchema(DataBagSchema):
     """Provider schema for Tracing."""
+    app: TracingProviderData
+
+
+class RequirerSchema(DataBagSchema):
+    """Requirer schema for Tracing."""


### PR DESCRIPTION
requirer becomes provider and viceversa in the (still draft) `tracing` relation interface v0.

this change is required to address some CMR-related networking concerns, and it is somewhat more intuitive that tempo is seen as the provider of tracing (as a service) rather than the requirer of traces (as data).