### PR TITLE
Fix tracing test

### DIFF
--- a/.github/workflows/discover.yaml
+++ b/.github/workflows/discover.yaml
@@ -18,6 +18,7 @@ jobs:
           python-version: 3.8
       - name: install interface-tester
         run: |
-          python -m pip install pytest-interface-tester
+          # TODO remove "ops<2.5": https://github.com/canonical/ops-scenario/issues/48
+          python -m pip install pytest-interface-tester "ops<2.5"
       - name: run discover
         run: interface_tester discover

--- a/docs/json_schemas/tracing/v0/provider.json
+++ b/docs/json_schemas/tracing/v0/provider.json
@@ -51,8 +51,8 @@
       "title": "TracingProviderData",
       "type": "object",
       "properties": {
-        "url": {
-          "title": "Url",
+        "host": {
+          "title": "Host",
           "type": "string"
         },
         "ingesters": {
@@ -64,7 +64,7 @@
         }
       },
       "required": [
-        "url",
+        "host",
         "ingesters"
       ]
     }

--- a/interfaces/tracing/v0/interface_tests/provider_tests.py
+++ b/interfaces/tracing/v0/interface_tests/provider_tests.py
@@ -33,9 +33,9 @@ def test_no_data_on_joined(output_state: State):
             interface='tracing',
             remote_app_name='remote',
             local_app_data={
-                "hostname": "foo.com",
+                "host": "foo.com",
                 "ingesters": json.dumps([
-                    {"type": "otlp_grpc",
+                    {"protocol": "otlp_grpc",
                      "port": "4242"}
                 ])
             }

--- a/interfaces/tracing/v0/schema.py
+++ b/interfaces/tracing/v0/schema.py
@@ -41,7 +41,7 @@ class Ingester(BaseModel):
 
 
 class TracingProviderData(BaseModel):
-    url: str
+    host: str
     ingesters: Json[List[Ingester]]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,7 @@ commands =
 [testenv:build-json-schemas]
 description = build json schemas in docs/
 deps =
+    ops==2.2.0  # https://github.com/canonical/ops-scenario/issues/48
     .[json_schemas]
 setenv =
     PYTHONPATH={toxinidir}


### PR DESCRIPTION
Currently, the tracing tests are outdated and error out with:

```
ERROR    interface_tester.interface_test:runner.py:55 Failed check 3: validating schema on scene output: 2 validation errors for ProviderSchema
app -> url
  field required (type=value_error.missing)
app -> ingesters -> 0 -> protocol
  field required (type=value_error.missing)
```

As well as:
```
  File "/.../charm-relation-interfaces/.tox/build-json-schemas/lib/python3.10/site-packages/scenario/fs_mocks.py", line 7, in <module>
    from ops.testing import _TestingFilesystem, _TestingStorageMount  # noqa
ImportError: cannot import name '_TestingFilesystem' from 'ops.testing' (/.../charm-relation-interfaces/.tox/build-json-schemas/lib/python3.10/site-packages/ops/testing.py)
```

This PR fixes those.