### PR TITLE
Remove reference to additional config keys that may be supported

### DIFF
--- a/interfaces/ingress/v2/README.md
+++ b/interfaces/ingress/v2/README.md
@@ -50,8 +50,7 @@ All fields are json-serialized.
 ### Requirer
 
 Exposes the unit name (`name`), model name (`model`), hostname (`host`) and port (`port`) at which ingress should be provided. 
-`name`, `port` and `model` should be placed in the **application** databag. `host`, as it may differ per ingressed unit (e.g. if it's a fqdn), will be placed in the **unit** databags of the respective ingress-requesting units.
-Depending on the library being used (and the provider charm), additional configuration keys may be supported. 
+`name`, `port` and `model` should be placed in the **application** databag. `host`, as it may differ per ingressed unit (e.g. if it's a fqdn), will be placed in the **unit** databags of the respective ingress-requesting units. 
 
 #### Example
 ```yaml


### PR DESCRIPTION
I find this statement strange as it means that the relation is not entirely defined here, and that depending on some implementation there could be extra fields which aren't validated, nor documented.
In my opinion this shouldn't be allowed, the relation should be clearly defined and any library, requirer, provider should strictly comply to that definition.
Any specific configuration should be managed in a `*-route` relation.