### PR TITLE
Adding info about the fiveg_n4 interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,13 @@ To quickly get started, see the [template interface](https://github.com/canonica
 
 ### Telco
 
-| Category   | Interface                                        |                               Status                                |
-|------------|:-------------------------------------------------|:-------------------------------------------------------------------:|
-| Charmed 5G | [`fiveg_nrf`](interfaces/fiveg_nrf/v0/README.md) | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-|            | [`fiveg_n2`](interfaces/fiveg_n2/v0/README.md)   | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-|          | [`fiveg_n3`](interfaces/fiveg_n3/v0/README.md)     | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+| Category   | Interface                                         |                               Status                                |
+|------------|:--------------------------------------------------|:-------------------------------------------------------------------:|
+| Charmed 5G | [`fiveg_nrf`](interfaces/fiveg_nrf/v0/README.md)  | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+|            | [`fiveg_n2`](interfaces/fiveg_n2/v0/README.md)    | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+|            | [`fiveg_n3`](interfaces/fiveg_n3/v0/README.md)    | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+|            | [`fiveg_n4`](interfaces/fiveg_n4/v0/README.md)    | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+
 
 For a more detailed explanation of statuses and how they should be used, see [the legend](https://github.com/canonical/charm-relation-interfaces/blob/main/LEGEND.md).
 

--- a/docs/json_schemas/fiveg_n4/v0/provider.json
+++ b/docs/json_schemas/fiveg_n4/v0/provider.json
@@ -1,0 +1,49 @@
+{
+  "title": "ProviderSchema",
+  "description": "Provider schema for fiveg_n4.",
+  "type": "object",
+  "properties": {
+    "unit": {
+      "$ref": "#/definitions/BaseModel"
+    },
+    "app": {
+      "$ref": "#/definitions/FivegN4ProviderAppData"
+    }
+  },
+  "required": [
+    "app"
+  ],
+  "definitions": {
+    "BaseModel": {
+      "title": "BaseModel",
+      "type": "object",
+      "properties": {}
+    },
+    "FivegN4ProviderAppData": {
+      "title": "FivegN4ProviderAppData",
+      "type": "object",
+      "properties": {
+        "upf_hostname": {
+          "title": "Upf Hostname",
+          "description": "Name of the host exposing the UPF's N4 interface.",
+          "examples": [
+            "upf.uplane-cloud.canonical.com"
+          ],
+          "type": "string"
+        },
+        "upf_port": {
+          "title": "Upf Port",
+          "description": "Port on which UPF's N4 interface is exposed.",
+          "examples": [
+            8805
+          ],
+          "type": "integer"
+        }
+      },
+      "required": [
+        "upf_hostname",
+        "upf_port"
+      ]
+    }
+  }
+}

--- a/docs/json_schemas/fiveg_n4/v0/requirer.json
+++ b/docs/json_schemas/fiveg_n4/v0/requirer.json
@@ -1,0 +1,20 @@
+{
+  "title": "RequirerSchema",
+  "description": "Requirer schema for fiveg_n4.",
+  "type": "object",
+  "properties": {
+    "unit": {
+      "$ref": "#/definitions/BaseModel"
+    },
+    "app": {
+      "$ref": "#/definitions/BaseModel"
+    }
+  },
+  "definitions": {
+    "BaseModel": {
+      "title": "BaseModel",
+      "type": "object",
+      "properties": {}
+    }
+  }
+}

--- a/interfaces/fiveg_n4/v0/README.md
+++ b/interfaces/fiveg_n4/v0/README.md
@@ -8,7 +8,7 @@ to the Data Network, policy enforcement and data buffering.
 
 The `fiveg_n4` relation interface describes the expected behavior of any charm claiming to be able 
 to provide or consume the UPF information in order to establish communication over the N4 interface. 
-In a typical 5G network, the N4 interface is used between UPF and AMF. 
+In a typical 5G network, the N4 interface is used between UPF and SMF. 
 
 ## Direction
 

--- a/interfaces/fiveg_n4/v0/README.md
+++ b/interfaces/fiveg_n4/v0/README.md
@@ -1,0 +1,53 @@
+# `fiveg_n4`
+
+## Usage
+
+Within 5G, the User Plane Function (UPF) supports features and capabilities to facilitate 
+user plane operation. Examples include: packet routing and forwarding, interconnection 
+to the Data Network, policy enforcement and data buffering.
+
+The `fiveg_n4` relation interface describes the expected behavior of any charm claiming to be able 
+to provide or consume the UPF information in order to establish communication over the N4 interface. 
+In a typical 5G network, the N4 interface is used between UPF and AMF. 
+
+## Direction
+
+```mermaid
+flowchart TD
+    Provider -- Hostname, Port --> Requirer
+```
+
+As with all Juju relations, the `fiveg_n4` interface consists of two parties: a Provider 
+and a Requirer.
+
+## Behavior
+
+Both the Requirer and the Provider need to adhere to criteria to be considered compatible 
+with the interface.
+
+### Provider
+
+- Is expected to provide the hostname and the port of the UPF's N4 interface.
+
+### Requirer
+
+- Is expected to consume the hostname and the port of the UPF's N4 interface in order to establish 
+  communication over that interface.
+
+## Relation Data
+
+[\[Pydantic Schema\]](./schema.py)
+
+#### Example
+
+```yaml
+provider:
+  app: {
+    "upf_hostname": "upf.uplane-cloud.canonical.com",
+    "upf_port": "8805"
+  }
+  unit: {}
+requirer:
+  app: {}
+  unit: {}
+```

--- a/interfaces/fiveg_n4/v0/charms.yaml
+++ b/interfaces/fiveg_n4/v0/charms.yaml
@@ -1,0 +1,2 @@
+providers: []
+requirers: []

--- a/interfaces/fiveg_n4/v0/schema.py
+++ b/interfaces/fiveg_n4/v0/schema.py
@@ -1,14 +1,18 @@
 """This file defines the schemas for the provider and requirer sides of the `fiveg_n4` interface.
-It exposes two interfaces.schema_base.DataBagSchema subclasses called:
-- ProviderSchema
-- RequirerSchema
+
+It exposes two `interfaces.schema_base.DataBagSchema` subclasses called:
+- `ProviderSchema`
+- `RequirerSchema`
+
 Examples:
+
     ProviderSchema:
         unit: <empty>
         app: {
             "upf_hostname": "upf.uplane-cloud.canonical.com",
             "upf_port": 8805
         }
+
     RequirerSchema:
         unit: <empty>
         app:  <empty>

--- a/interfaces/fiveg_n4/v0/schema.py
+++ b/interfaces/fiveg_n4/v0/schema.py
@@ -1,0 +1,39 @@
+"""This file defines the schemas for the provider and requirer sides of the `fiveg_n4` interface.
+It exposes two interfaces.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {
+            "upf_hostname": "upf.uplane-cloud.canonical.com",
+            "upf_port": 8805
+        }
+    RequirerSchema:
+        unit: <empty>
+        app:  <empty>
+"""
+
+from pydantic import BaseModel, IPvAnyAddress, Field
+
+from interface_tester.schema_base import DataBagSchema
+
+
+class FivegN4ProviderAppData(BaseModel):
+    upf_hostname: str = Field(
+        description="Name of the host exposing the UPF's N4 interface.",
+        examples=["upf.uplane-cloud.canonical.com"]
+    )
+    upf_port: int = Field(
+        description="Port on which UPF's N4 interface is exposed.",
+        examples=[8805]
+    )
+
+
+class ProviderSchema(DataBagSchema):
+    """Provider schema for fiveg_n4."""
+    app: FivegN4ProviderAppData
+
+
+class RequirerSchema(DataBagSchema):
+    """Requirer schema for fiveg_n4."""

--- a/interfaces/fiveg_n4/v0/schema.py
+++ b/interfaces/fiveg_n4/v0/schema.py
@@ -18,7 +18,7 @@ Examples:
         app:  <empty>
 """
 
-from pydantic import BaseModel, IPvAnyAddress, Field
+from pydantic import BaseModel, Field
 
 from interface_tester.schema_base import DataBagSchema
 


### PR DESCRIPTION
**Overview:**
In 5G Core, the `N4` interface is used to establish a bridge between the User Plane and the Control Plane. 
A new charm relation interface facilitates connectivity over the N4 interface, between the interface provider and requirer.

**Reference:**
https://docs.google.com/document/d/1s3U82GTUZFJ9mEhiHig0oAl44F0fq3eQT2PNv1uV75g/edit