### PR TITLE
Creates sdcore management interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ To quickly get started, see the [template interface](https://github.com/canonica
 |            | [`fiveg_n2`](interfaces/fiveg_n2/v0/README.md)    | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 |            | [`fiveg_n3`](interfaces/fiveg_n3/v0/README.md)    | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 |            | [`fiveg_n4`](interfaces/fiveg_n4/v0/README.md)    | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+|          | [`sdcore_management`](interfaces/sdcore_management/v0/README.md)     | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 
 
 For a more detailed explanation of statuses and how they should be used, see [the legend](https://github.com/canonical/charm-relation-interfaces/blob/main/LEGEND.md).

--- a/docs/json_schemas/interfaces/sdcore_management/provider.json
+++ b/docs/json_schemas/interfaces/sdcore_management/provider.json
@@ -1,0 +1,43 @@
+{
+  "title": "ProviderSchema",
+  "description": "The schema for the provider side of the sdcore_management interface.",
+  "type": "object",
+  "properties": {
+    "unit": {
+      "$ref": "#/definitions/BaseModel"
+    },
+    "app": {
+      "$ref": "#/definitions/SdcoreManagementProviderAppData"
+    }
+  },
+  "required": [
+    "app"
+  ],
+  "definitions": {
+    "BaseModel": {
+      "title": "BaseModel",
+      "type": "object",
+      "properties": {}
+    },
+    "SdcoreManagementProviderAppData": {
+      "title": "SdcoreManagementProviderAppData",
+      "type": "object",
+      "properties": {
+        "management_url": {
+          "title": "Management Url",
+          "description": "The endpoint to use to manage SD-Core network.",
+          "examples": [
+            "http://1.2.3.4:1234"
+          ],
+          "minLength": 1,
+          "maxLength": 2083,
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "management_url"
+      ]
+    }
+  }
+}

--- a/docs/json_schemas/interfaces/sdcore_management/requirer.json
+++ b/docs/json_schemas/interfaces/sdcore_management/requirer.json
@@ -1,0 +1,20 @@
+{
+  "title": "RequirerSchema",
+  "description": "The schema for the requirer side of the sdcore_management interface.",
+  "type": "object",
+  "properties": {
+    "unit": {
+      "$ref": "#/definitions/BaseModel"
+    },
+    "app": {
+      "$ref": "#/definitions/BaseModel"
+    }
+  },
+  "definitions": {
+    "BaseModel": {
+      "title": "BaseModel",
+      "type": "object",
+      "properties": {}
+    }
+  }
+}

--- a/interfaces/sdcore_management/README.md
+++ b/interfaces/sdcore_management/README.md
@@ -2,11 +2,11 @@
 
 ## Usage
 
-Within Charmed-5G, components that need to make configuration changes to the network need to have access to the configuration and management service.
+Within Charmed-5G, components that makes configuration changes to the network need to have access to the configuration and management service.
 
-The `sdcore_management` relation interface describes the expected behavior of any charm claiming to be able to provide or consume the information to access the SD-Core configuration service.
+The `sdcore_management` relation interface describes the expected behavior of any charm claiming to be able to provide or consume the information to access the configuration service in SD-Core.
 
-SD-Core Webui Operator that allows the configuration of the SD-Core network within Charmed-5G is a typical provider and SD-Core NMS (Network Management System) Operator that provides a user interface to manage and configure the network is a typical requirer of this relation.
+SD-Core Webui Operator that is responsible for the configuration of the SD-Core network within Charmed-5G is a typical provider and SD-Core NMS (Network Management System) Operator that provides a user interface to manage and configure the network is a typical requirer of this relation.
 
 ## Direction
 

--- a/interfaces/sdcore_management/README.md
+++ b/interfaces/sdcore_management/README.md
@@ -2,9 +2,9 @@
 
 ## Usage
 
-Within Charmed-5G, components that makes configuration changes to the network need to have access to the configuration and management service.
+Within Charmed-5G, the components that makes configuration changes to the network require access to the configuration and management service.
 
-The `sdcore_management` relation interface describes the expected behavior of any charm claiming to be able to provide or consume the information to access the configuration service in SD-Core.
+The `sdcore_management` relation interface describes the expected behavior of any charm claiming to provide or consume the information to access the configuration service in SD-Core.
 
 SD-Core Webui Operator that is responsible for the configuration of the SD-Core network within Charmed-5G is a typical provider and SD-Core NMS (Network Management System) Operator that provides a user interface to manage and configure the network is a typical requirer of this relation.
 

--- a/interfaces/sdcore_management/README.md
+++ b/interfaces/sdcore_management/README.md
@@ -1,0 +1,47 @@
+# `sdcore_management`
+
+## Usage
+
+Within Charmed-5G, components that need to make configuration changes to the network need to have access to the configuration and management service.
+
+The `sdcore_management` relation interface describes the expected behavior of any charm claiming to be able to provide or consume the information to access the SD-Core configuration service.
+
+SD-Core Webui Operator that allows the configuration of the SD-Core network within Charmed-5G is a typical provider and SD-Core NMS (Network Management System) Operator that provides a user interface to manage and configure the network is a typical requirer of this relation.
+
+## Direction
+
+```mermaid
+flowchart TD
+    Provider -- management_url --> Requirer
+```
+
+As with all Juju relations, the `sdcore_management` interface consists of two parties: a Provider and a Requirer.
+
+## Behavior
+
+Both the Requirer and the Provider need to adhere to criteria to be considered compatible with the interface.
+
+### Provider
+
+- Is expected to provide the address to access the SD-Core configuration service endpoint.
+
+### Requirer
+
+- Is expected to use the endpoint address provided to connect to the configuration service.
+
+## Relation Data
+
+[\[Pydantic Schema\]](./schema.py)
+
+#### Example
+
+```yaml
+provider:
+  app: {
+    "management_url": "http://1.2.3.4:1234",
+  }
+  unit: {}
+requirer:
+  app: {}
+  unit: {}
+```

--- a/interfaces/sdcore_management/charms.yaml
+++ b/interfaces/sdcore_management/charms.yaml
@@ -1,0 +1,2 @@
+providers: []
+requirers: []

--- a/interfaces/sdcore_management/schema.py
+++ b/interfaces/sdcore_management/schema.py
@@ -18,15 +18,19 @@ Examples:
 from interface_tester.schema_base import DataBagSchema
 from pydantic import BaseModel, Field, HttpUrl
 
+
 class SdcoreManagementProviderAppData(BaseModel):
     management_url: HttpUrl = Field(
         description="The endpoint to use to manage SD-Core network.",
-        examples=["http://1.2.3.4:1234"]
+        examples=["http://1.2.3.4:1234"],
     )
+
 
 class ProviderSchema(DataBagSchema):
     """The schema for the provider side of the sdcore_management interface."""
+
     app: SdcoreManagementProviderAppData
+
 
 class RequirerSchema(DataBagSchema):
     """The schema for the requirer side of the sdcore_management interface."""

--- a/interfaces/sdcore_management/schema.py
+++ b/interfaces/sdcore_management/schema.py
@@ -1,0 +1,32 @@
+"""This file defines the schemas for the provider and requirer sides of the `sdcore_management` relation interface.
+
+It must expose two interfaces.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {
+            "management_endpoint": "http://1.2.3.4:1234",
+        }
+    RequirerSchema:
+        unit: <empty>
+        app:  <empty>
+"""
+
+from interface_tester.schema_base import DataBagSchema
+from pydantic import BaseModel, Field, HttpUrl
+
+class SdcoreManagementProviderAppData(BaseModel):
+    management_url: HttpUrl = Field(
+        description="The endpoint to use to manage SD-Core network.",
+        examples=["http://1.2.3.4:1234"]
+    )
+
+class ProviderSchema(DataBagSchema):
+    """The schema for the provider side of the sdcore_management interface."""
+    app: SdcoreManagementProviderAppData
+
+class RequirerSchema(DataBagSchema):
+    """The schema for the requirer side of the sdcore_management interface."""


### PR DESCRIPTION
SD-Core Webui is used to configure SD-Core.
In Charmed-5G SD-Core NMS Operator provides a user interface that leverages SD-Core Webui Operator to configure the network based on user input.

This spec describes the relation interface that is needed that Webui to pass the needed url to the NMS.