### PR TITLE
Add fiveg_gnb_identity relation interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,12 @@ To quickly get started, see the [template interface](https://github.com/canonica
 
 | Category   | Interface                                         |                               Status                                |
 |------------|:--------------------------------------------------|:-------------------------------------------------------------------:|
-| Charmed 5G | [`fiveg_nrf`](interfaces/fiveg_nrf/v0/README.md)  | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+| Charmed 5G | [`fiveg_gnb_identity`](interfaces/fiveg_gnb_identity/v0/README.md) | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+|            | [`fiveg_nrf`](interfaces/fiveg_nrf/v0/README.md)  | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 |            | [`fiveg_n2`](interfaces/fiveg_n2/v0/README.md)    | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 |            | [`fiveg_n3`](interfaces/fiveg_n3/v0/README.md)    | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 |            | [`fiveg_n4`](interfaces/fiveg_n4/v0/README.md)    | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
-|          | [`sdcore_management`](interfaces/sdcore_management/v0/README.md)     | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
+|            | [`sdcore_management`](interfaces/sdcore_management/v0/README.md)   | ![Status: Draft](https://img.shields.io/badge/Status-Draft-orange)  |
 
 
 For a more detailed explanation of statuses and how they should be used, see [the legend](https://github.com/canonical/charm-relation-interfaces/blob/main/LEGEND.md).

--- a/docs/json_schemas/fiveg_gnb_identity/v0/provider.json
+++ b/docs/json_schemas/fiveg_gnb_identity/v0/provider.json
@@ -1,0 +1,49 @@
+{
+  "title": "ProviderSchema",
+  "description": "The schema for the provider side of the fiveg_gnb_identity interface.",
+  "type": "object",
+  "properties": {
+    "unit": {
+      "$ref": "#/definitions/BaseModel"
+    },
+    "app": {
+      "$ref": "#/definitions/FivegGnbIdentityProviderAppData"
+    }
+  },
+  "required": [
+    "app"
+  ],
+  "definitions": {
+    "BaseModel": {
+      "title": "BaseModel",
+      "type": "object",
+      "properties": {}
+    },
+    "FivegGnbIdentityProviderAppData": {
+      "title": "FivegGnbIdentityProviderAppData",
+      "type": "object",
+      "properties": {
+        "gnb_name": {
+          "title": "Gnb Name",
+          "description": "Name of the gnB.",
+          "examples": [
+            "gnb001"
+          ],
+          "type": "string"
+        },
+        "tac": {
+          "title": "Tac",
+          "description": "Tracking Area Code",
+          "examples": [
+            "0001"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "gnb_name",
+        "tac"
+      ]
+    }
+  }
+}

--- a/docs/json_schemas/fiveg_gnb_identity/v0/requirer.json
+++ b/docs/json_schemas/fiveg_gnb_identity/v0/requirer.json
@@ -1,0 +1,20 @@
+{
+  "title": "RequirerSchema",
+  "description": "The schema for the requirer side of the fiveg_gnb_identity interface.",
+  "type": "object",
+  "properties": {
+    "unit": {
+      "$ref": "#/definitions/BaseModel"
+    },
+    "app": {
+      "$ref": "#/definitions/BaseModel"
+    }
+  },
+  "definitions": {
+    "BaseModel": {
+      "title": "BaseModel",
+      "type": "object",
+      "properties": {}
+    }
+  }
+}

--- a/interfaces/fiveg_gnb_identity/v0/README.md
+++ b/interfaces/fiveg_gnb_identity/v0/README.md
@@ -1,0 +1,49 @@
+# `fiveg_gnb_identity`
+
+## Usage
+
+Within 5G, the gNodeB (a 5G base station) identity needs to be known by other components.
+
+The `fiveg_gnb_identity` relation interface describes the expected behavior of any charm claiming to be able to provide or consume the gNodeB identity information.
+
+In a typical 5G network, the provider of this interface would be a gNodeB. The requirer of this interface would be the NMS (Network Management System).
+
+## Direction
+
+```mermaid
+flowchart TD
+    Provider -- gNodeB Name, TAC --> Requirer
+```
+
+As with all Juju relations, the `fiveg_gnb_identity` interface consists of two parties: a Provider and a Requirer.
+
+## Behavior
+
+Both the Requirer and the Provider need to adhere to criteria to be considered compatible with the interface.
+
+### Provider
+
+- Is expected to provide the name of the gNodeB and TAC (Traking Area Code).
+    
+
+### Requirer
+
+- Is expected to use the name of the gNodeB name and TAC (Traking Area Code).
+
+## Relation Data
+
+[\[Pydantic Schema\]](./schema.py)
+
+#### Example
+
+```yaml
+provider:
+  app: {
+    "gnb_name": "gnb001",
+    "tac": "001"
+  }
+  unit: {}
+requirer:
+  app: {}
+  unit: {}
+```

--- a/interfaces/fiveg_gnb_identity/v0/charms.yaml
+++ b/interfaces/fiveg_gnb_identity/v0/charms.yaml
@@ -1,0 +1,2 @@
+providers: []
+requirers: []

--- a/interfaces/fiveg_gnb_identity/v0/schema.py
+++ b/interfaces/fiveg_gnb_identity/v0/schema.py
@@ -1,0 +1,40 @@
+"""This file defines the schemas for the provider and requirer sides of the `fiveg_gnb_identity` relation interface.
+
+It must expose two interfaces.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {
+            "gnb_name": "gnb001",
+            "tac": "0001"
+        }
+    RequirerSchema:
+        unit: <empty>
+        app:  <empty>
+"""
+
+from interface_tester.schema_base import DataBagSchema
+from pydantic import BaseModel, Field
+
+
+class FivegGnbIdentityProviderAppData(BaseModel):
+    gnb_name: str = Field(
+        description="Name of the gnB.",
+        examples=["gnb001"]
+    )
+    tac: str = Field(
+        description="Tracking Area Code",
+        examples=["0001"]
+    )
+
+
+class ProviderSchema(DataBagSchema):
+    """The schema for the provider side of the fiveg_gnb_identity interface."""
+    app: FivegGnbIdentityProviderAppData
+
+
+class RequirerSchema(DataBagSchema):
+    """The schema for the requirer side of the fiveg_gnb_identity interface."""


### PR DESCRIPTION
The `fiveg_gnb_identity` relation interface describes the expected behavior of any charm claiming to be able to provide or consume the gNodeB identity information.

In a typical 5G network, the provider of this interface would be a gNodeB. The requirer of this interface would be the NMS (Network Management System).