### PR TITLE
Fix vault-kv schema description

### DIFF
--- a/docs/json_schemas/vault_kv/v0/requirer.json
+++ b/docs/json_schemas/vault_kv/v0/requirer.json
@@ -21,15 +21,19 @@
       "properties": {
         "egress_subnet": {
           "title": "Egress Subnet",
-          "default": "Egress subnet to use, in CIDR notation.",
+          "description": "Egress subnet to use, in CIDR notation.",
           "type": "string"
         },
         "nonce": {
           "title": "Nonce",
-          "default": "Uniquely identifying value for this unit. `secrets.token_hex(16)` is recommended.",
+          "description": "Uniquely identifying value for this unit. `secrets.token_hex(16)` is recommended.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "egress_subnet",
+        "nonce"
+      ]
     },
     "AppVaultKvRequirerSchema": {
       "title": "AppVaultKvRequirerSchema",
@@ -37,10 +41,13 @@
       "properties": {
         "mount_suffix": {
           "title": "Mount Suffix",
-          "default": "Suffix to append to the mount name to get the KV mount.",
+          "description": "Suffix to append to the mount name to get the KV mount.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "mount_suffix"
+      ]
     }
   }
 }

--- a/interfaces/vault_kv/v0/schema.py
+++ b/interfaces/vault_kv/v0/schema.py
@@ -32,13 +32,18 @@ class VaultKvProviderSchema(BaseModel):
 
 
 class AppVaultKvRequirerSchema(BaseModel):
-    mount_suffix: str = Field("Suffix to append to the mount name to get the KV mount.")
+    mount_suffix: str = Field(
+        description="Suffix to append to the mount name to get the KV mount."
+    )
 
 
 class UnitVaultKvRequirerSchema(BaseModel):
-    egress_subnet: str = Field("Egress subnet to use, in CIDR notation.")
+    egress_subnet: str = Field(description="Egress subnet to use, in CIDR notation.")
     nonce: str = Field(
-        "Uniquely identifying value for this unit. `secrets.token_hex(16)` is recommended."
+        description=(
+            "Uniquely identifying value for this unit."
+            " `secrets.token_hex(16)` is recommended."
+        )
     )
 
 


### PR DESCRIPTION
For some items, no keywords was used to set the description, meaning the description was actually used as default value.