### PR TITLE
Set TAC as integer in fiveg_gnb_identity relation interface

### DIFF
--- a/docs/json_schemas/fiveg_gnb_identity/v0/provider.json
+++ b/docs/json_schemas/fiveg_gnb_identity/v0/provider.json
@@ -35,9 +35,9 @@
           "title": "Tac",
           "description": "Tracking Area Code",
           "examples": [
-            "0001"
+            1
           ],
-          "type": "string"
+          "type": "integer"
         }
       },
       "required": [

--- a/interfaces/fiveg_gnb_identity/v0/README.md
+++ b/interfaces/fiveg_gnb_identity/v0/README.md
@@ -40,7 +40,7 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
 provider:
   app: {
     "gnb_name": "gnb001",
-    "tac": "001"
+    "tac": 1
   }
   unit: {}
 requirer:

--- a/interfaces/fiveg_gnb_identity/v0/schema.py
+++ b/interfaces/fiveg_gnb_identity/v0/schema.py
@@ -25,9 +25,9 @@ class FivegGnbIdentityProviderAppData(BaseModel):
         description="Name of the gnB.",
         examples=["gnb001"]
     )
-    tac: str = Field(
+    tac: int = Field(
         description="Tracking Area Code",
-        examples=["0001"]
+        examples=[1]
     )
 
 

--- a/interfaces/fiveg_gnb_identity/v0/schema.py
+++ b/interfaces/fiveg_gnb_identity/v0/schema.py
@@ -9,7 +9,7 @@ Examples:
         unit: <empty>
         app: {
             "gnb_name": "gnb001",
-            "tac": "0001"
+            "tac": 1
         }
     RequirerSchema:
         unit: <empty>


### PR DESCRIPTION
We decided to set the Tracking Area Code (TAC) as an integer instead of a string.