### PR TITLE
[DPE-2798][mysql_client] Relation Secrets

### DIFF
--- a/interfaces/mysql_client/v0/schemas/requirer.json
+++ b/interfaces/mysql_client/v0/schemas/requirer.json
@@ -19,6 +19,14 @@
                 "myapp"
             ]
         },
+        "requested-secrets": {
+            "title": "Requested Secrets",
+            "description": "Any provider field which should be transfered as Juju Secret",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
         "extra-user-roles": {
             "title": "Extra-user-roles",
             "description": "Any extra user roles requested by the requirer",


### PR DESCRIPTION
MySQL Charms are using Juju Secrets in Charms Relations. This requires to follow a new protocol, described in this document.

Rendered version of the document can be viewed here: https://github.com/juditnovak/charm-relation-interfaces/blob/DPE-2798_relation_secrets_for_mysql/interfaces/mysql_client/v0/README.md