### PR TITLE
Add openfga v1

### DIFF
--- a/docs/json_schemas/openfga/v1/provider.json
+++ b/docs/json_schemas/openfga/v1/provider.json
@@ -1,0 +1,61 @@
+{
+  "title": "ProviderSchema",
+  "description": "Provider schema for OpenFGA.",
+  "type": "object",
+  "properties": {
+    "unit": {
+      "$ref": "#/definitions/BaseModel"
+    },
+    "app": {
+      "$ref": "#/definitions/OpenFGAProviderData"
+    }
+  },
+  "required": [
+    "app"
+  ],
+  "definitions": {
+    "BaseModel": {
+      "title": "BaseModel",
+      "type": "object",
+      "properties": {}
+    },
+    "OpenFGAProviderData": {
+      "title": "OpenFGAProviderData",
+      "type": "object",
+      "properties": {
+        "grpc_api_url": {
+          "title": "gRPC URL",
+          "description": "The URL of the gRPC API.",
+          "type": "string"
+        },
+        "http_api_url": {
+          "title": "HTTP URL",
+          "description": "The URL of the HTTP API.",
+          "type": "string"
+        },
+        "token_secret_id": {
+          "title": "Secret ID of the OpenFGA token",
+          "description": "Secret ID of the preshared token to be used to connect to the OpenFGA service.",
+          "type": "string"
+        },
+        "token": {
+          "title": "The OpenFGA token",
+          "description": "The preshared token to be used to connect to the OpenFGA service, to be used when juju secrets are not available.",
+          "type": "string"
+        },
+        "store_id": {
+          "title": "OpenFGA store ID",
+          "description": "ID of the authentication store that was created.",
+          "examples": [
+            "01GK13VYZK62Q1T0X55Q2BHYD6"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "grpc_api_url",
+        "http_api_url"
+      ]
+    }
+  }
+}

--- a/docs/json_schemas/openfga/v1/requirer.json
+++ b/docs/json_schemas/openfga/v1/requirer.json
@@ -1,0 +1,40 @@
+{
+  "title": "RequirerSchema",
+  "description": "Requirer schema for OpenFGA.",
+  "type": "object",
+  "properties": {
+    "unit": {
+      "$ref": "#/definitions/BaseModel"
+    },
+    "app": {
+      "$ref": "#/definitions/OpenFGARequirerData"
+    }
+  },
+  "required": [
+    "app"
+  ],
+  "definitions": {
+    "BaseModel": {
+      "title": "BaseModel",
+      "type": "object",
+      "properties": {}
+    },
+    "OpenFGARequirerData": {
+      "title": "OpenFGARequirerData",
+      "type": "object",
+      "properties": {
+        "store_name": {
+          "title": "Authorization store name",
+          "description": "The name of the authorization store.",
+          "examples": [
+            "auth_store"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "store_name"
+      ]
+    }
+  }
+}

--- a/interfaces/openfga/v1/README.md
+++ b/interfaces/openfga/v1/README.md
@@ -1,0 +1,67 @@
+# `openfga`
+
+## Usage
+
+This relation interface describes the expected behaviour of any charm claiming to be able to interact with a OpenFGA.
+
+In most cases, this will be accomplished using the [openfga library](https://github.com/canonical/openfga-operator/blob/main/charms/openfga-k8s/lib/charms/openfga_k8s/v0/openfga.py), although charm developers are free to provide alternative libraries as long as they fulfil the behavioural and schematic requirements described in this document.
+
+## Direction
+
+```mermaid
+flowchart TD
+    Requirer -- store_name --> Provider
+    Provider -- store_id, token_secret_id, token, grpc_api_url, http_api_url --> Requirer
+```
+
+As with all Juju relations, the `openfga` interface consists of two parties: a Provider (openfga charm), and a Requirer (application charm). The Requirer will be expected to expose an authentication store name, and the Provider will create and forward new unique credentials (along with other optional fields), which can be used to access the OpenFGA store.
+
+## Behavior
+
+Both the Requirer and the Provider need to adhere to the following criteria to be considered compatible with the interface.
+
+### Provider
+- Is expected to create an authentication store in OpenFGA when the requirer provides the `store_name` field.
+- Is expected to expose to the Requirer `store_id`, `token_secret_id`, `token`, `grpc_api_url` and `http_api_url` fields in the *application* databag.
+
+### Requirer
+- Is expected to provide the `store_name` it requires in its application databag
+- Is expected to use the `store_id`, `token_secret_id`, `token`, `grpc_api_url` and `http_api_url` fields, when exposed by the `Provider`, to set up an OpenFGA connection.
+
+## Relation Data
+
+### Provider
+
+[\[JSON Schema\]](./schemas/provider.json)
+
+Provider exposes `store_id`, `token_secret_id`, `token`, `grpc_api_url` and `http_api_url` fields in the **application** databag.
+
+
+#### Example
+```yaml
+  relation-info:
+  - endpoint: openfga
+    related-endpoint: openfga
+    application-data:
+      token_secret_id: "10559c09-6416-40b0-9402-54b6e28edd3a"
+      token: null
+      store_id: "01GK13VYZK62Q1T0X55Q2BHYD6"
+      grpc_api_url: "http://10.10.0.17:8081"
+      http_api_url: "http://10.10.0.17:8080"
+```
+
+### Requirer
+
+[\[JSON Schema\]](./schemas/requirer.json)
+
+The Requirer exposes the store name for which authorization is requested in the **application** databag.
+
+#### Example
+
+```yaml
+  relation-info:
+  - endpoint: openfga
+    related-endpoint: openfga
+    application-data:
+      store_name: "test-store"
+```

--- a/interfaces/openfga/v1/charms.yaml
+++ b/interfaces/openfga/v1/charms.yaml
@@ -1,0 +1,3 @@
+providers: []
+
+requirers: []

--- a/interfaces/openfga/v1/schema.py
+++ b/interfaces/openfga/v1/schema.py
@@ -1,0 +1,87 @@
+# Copyright 2023 Canonical
+# See LICENSE file for licensing details.
+"""This file defines the schemas for the provider and requirer sides of the openfga interface.
+
+It exposes two interfaces.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {"openfga":
+                 {"grpc_api_url": "http://10.10.0.17:8081",
+                  "http_api_url": "http://10.10.0.17:8080",
+                  "token": "test-token",
+                  "token_secret_id": null,
+                  "store_id": "01GK13VYZK62Q1T0X55Q2BHYD6",
+                 }
+             }
+
+    RequirerSchema:
+        unit: <empty>
+        app: {"store_name": "test-store-name"}
+"""
+from typing import Dict, Optional
+from interface_tester.schema_base import DataBagSchema
+from pydantic import BaseModel, Field, validator
+
+
+class OpenFGAProviderData(BaseModel):
+    grpc_api_url: str = Field(
+        description=("The URL of the gRPC API."),
+        title="gRPC URL",
+    )
+    http_api_url: str = Field(
+        description=("The URL of the HTTP API."),
+        title="HTTP URL",
+    )
+    token_secret_id: Optional[str] = Field(
+        description=(
+            "Secret ID of the preshared token to be used to connect to"
+            " the OpenFGA service."
+        ),
+        title="Secret ID of the OpenFGA token",
+        default=None,
+    )
+    token: Optional[str] = Field(
+        description=(
+            "The preshared token to be used to connect to the OpenFGA "
+            "service, to be used when juju secrets are not available."
+        ),
+        title="The OpenFGA token",
+        default=None,
+    )
+    store_id: Optional[str] = Field(
+        description="ID of the authentication store that was created.",
+        title="OpenFGA store ID",
+        examples=["01GK13VYZK62Q1T0X55Q2BHYD6"],
+        default=None,
+    )
+
+    @validator("token_secret_id", pre=True)
+    def validate_token(cls, v: str, values: Dict) -> str:  # noqa: N805
+        """Validate token_secret_id arg."""
+        if not v and not values["token"]:
+            raise ValueError("invalid scheme: neither of token and token_secret_id were defined")
+        return v
+
+
+class ProviderSchema(DataBagSchema):
+    """Provider schema for OpenFGA."""
+
+    app: OpenFGAProviderData
+
+
+class OpenFGARequirerData(BaseModel):
+    store_name: str = Field(
+        description="The name of the authorization store.",
+        title="Authorization store name",
+        examples=["auth_store"],
+    )
+
+
+class RequirerSchema(DataBagSchema):
+    """Requirer schema for OpenFGA."""
+
+    app: OpenFGARequirerData


### PR DESCRIPTION
Add openfga interface `v1`:
- Adds grpc endpoint
- Pass the URL as is instead of each component separately
- Adds the option to use a DNS hostname instead of IP
