### PR TITLE
[DPE-3357] Add S3 service account

### DIFF
--- a/interfaces/s3/v0/schemas/provider.json
+++ b/interfaces/s3/v0/schemas/provider.json
@@ -98,6 +98,19 @@
                 ]
             ]
         },
+        "service-account": {
+            "title": "Service account",
+            "description": "The service account file content, in base64",
+            "type": "string",
+            "items": {
+                "type": "string"
+            },
+            "examples": [
+                [
+                    "base64-encoded-ca-chain=="
+                ]
+            ]
+        },
         "s3-api-version": {
             "title": "S3 API signature",
             "description": "S3 protocol specific API signature.",


### PR DESCRIPTION
This PR adds the service account as an alternative key/ID for users, compared to access_/secret_keys. This is useful, for example, for GCS cloud.

The service account should be passed as a base64 string containing the file content.

This PR is related to: https://github.com/canonical/s3-integrator/pull/26