### PR TITLE
Redo dns-record interface

### DIFF
--- a/docs/json_schemas/dns_record/v0/provider.json
+++ b/docs/json_schemas/dns_record/v0/provider.json
@@ -8,15 +8,6 @@
     "DNSRecordProvider": {
       "description": "List statuses for the DNS records informed by the requirer.",
       "properties": {
-        "dns_domains": {
-          "description": "List statuses for the domains requested by the requirer.",
-          "items": {
-            "$ref": "#/$defs/DnsProviderData"
-          },
-          "name": "DNS domains",
-          "title": "Dns Domains",
-          "type": "array"
-        },
         "dns_entries": {
           "description": "List of statuses for the DNS records requested by the requirer.",
           "items": {
@@ -28,7 +19,6 @@
         }
       },
       "required": [
-        "dns_domains",
         "dns_entries"
       ],
       "title": "DNSRecordProvider",

--- a/docs/json_schemas/dns_record/v0/provider.json
+++ b/docs/json_schemas/dns_record/v0/provider.json
@@ -51,7 +51,7 @@
           "default": null,
           "description": "Status description.",
           "examples": [
-            "incorrect username and password"
+            "incorrect credentials"
           ],
           "name": "Status description",
           "title": "Description",

--- a/docs/json_schemas/dns_record/v0/requirer.json
+++ b/docs/json_schemas/dns_record/v0/requirer.json
@@ -9,13 +9,11 @@
       "description": "List of domains for the provider to manage.",
       "properties": {
         "service_account": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/ServiceAccount"
-            }
-          ],
           "description": "Service account for authentication.",
-          "name": "Service account"
+          "examples": "secret:123213123123123123123",
+          "name": "Service account",
+          "title": "Service Account",
+          "type": "string"
         },
         "dns_entries": {
           "description": "List of DNS records for the provider to manage.",
@@ -153,35 +151,6 @@
         "uuid"
       ],
       "title": "RequirerEntries",
-      "type": "object"
-    },
-    "ServiceAccount": {
-      "properties": {
-        "username": {
-          "description": "Username for authentication.",
-          "examples": [
-            "user1",
-            "user2"
-          ],
-          "name": "Username",
-          "title": "Username",
-          "type": "string"
-        },
-        "password_id": {
-          "description": "Juju secret containing the user password.",
-          "examples": [
-            "secret:123213123123123123123"
-          ],
-          "name": "Password",
-          "title": "Password Id",
-          "type": "string"
-        }
-      },
-      "required": [
-        "username",
-        "password_id"
-      ],
-      "title": "ServiceAccount",
       "type": "object"
     }
   },

--- a/docs/json_schemas/dns_record/v0/requirer.json
+++ b/docs/json_schemas/dns_record/v0/requirer.json
@@ -35,6 +35,9 @@
     "RecordClass": {
       "const": "IN",
       "description": "Represent the DNS record classes.",
+      "enum": [
+        "IN"
+      ],
       "title": "RecordClass",
       "type": "string"
     },

--- a/docs/json_schemas/dns_record/v0/requirer.json
+++ b/docs/json_schemas/dns_record/v0/requirer.json
@@ -8,14 +8,14 @@
     "DNSRecordRequirer": {
       "description": "List of domains for the provider to manage.",
       "properties": {
-        "dns_domains": {
-          "description": "List of domains for the provider to manage.",
-          "items": {
-            "$ref": "#/$defs/RequirerDomains"
-          },
-          "name": "DNS domains",
-          "title": "Dns Domains",
-          "type": "array"
+        "service_account": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/ServiceAccount"
+            }
+          ],
+          "description": "Service account for authentication.",
+          "name": "Service account"
         },
         "dns_entries": {
           "description": "List of DNS records for the provider to manage.",
@@ -28,7 +28,7 @@
         }
       },
       "required": [
-        "dns_domains",
+        "service_account",
         "dns_entries"
       ],
       "title": "DNSRecordRequirer",
@@ -63,56 +63,6 @@
       ],
       "title": "RecordType",
       "type": "string"
-    },
-    "RequirerDomains": {
-      "properties": {
-        "domain": {
-          "description": "Domain name for the provider to manage.",
-          "examples": [
-            "cloud.canonical.com",
-            "staging.ubuntu.com"
-          ],
-          "minLength": 1,
-          "name": "Domain",
-          "title": "Domain",
-          "type": "string"
-        },
-        "username": {
-          "description": "Username for authentication.",
-          "examples": [
-            "user1",
-            "user2"
-          ],
-          "name": "Username",
-          "title": "Username",
-          "type": "string"
-        },
-        "password_id": {
-          "description": "Juju secret containing the user password.",
-          "examples": [
-            "secret:123213123123123123123"
-          ],
-          "name": "Password",
-          "title": "Password Id",
-          "type": "string"
-        },
-        "uuid": {
-          "description": "UUID for this domain.",
-          "examples": "550e8400-e29b-41d4-a716-446655440000",
-          "format": "uuid",
-          "name": "UUID",
-          "title": "Uuid",
-          "type": "string"
-        }
-      },
-      "required": [
-        "domain",
-        "username",
-        "password_id",
-        "uuid"
-      ],
-      "title": "RequirerDomains",
-      "type": "object"
     },
     "RequirerEntries": {
       "properties": {
@@ -203,6 +153,35 @@
         "uuid"
       ],
       "title": "RequirerEntries",
+      "type": "object"
+    },
+    "ServiceAccount": {
+      "properties": {
+        "username": {
+          "description": "Username for authentication.",
+          "examples": [
+            "user1",
+            "user2"
+          ],
+          "name": "Username",
+          "title": "Username",
+          "type": "string"
+        },
+        "password_id": {
+          "description": "Juju secret containing the user password.",
+          "examples": [
+            "secret:123213123123123123123"
+          ],
+          "name": "Password",
+          "title": "Password Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "username",
+        "password_id"
+      ],
+      "title": "ServiceAccount",
       "type": "object"
     }
   },

--- a/interfaces/dns_record/v0/README.md
+++ b/interfaces/dns_record/v0/README.md
@@ -9,8 +9,8 @@ This relation interface describes the expected behavior of any charm claiming to
 The `dns_record` interface implements a provider/requirer pattern. The requirer is a charm that wishes to create a set of DNS records, and the provider is the charm managing those.
 ```mermaid
 flowchart TD
-  Requirer -- dns_domains, dns_entries --> Provider
-  Provider -- dns_domains, dns_entries --> Requirer
+  Requirer -- service_account, dns_entries --> Provider
+  Provider -- dns_entries --> Requirer
 ```
 
 ## Behavior
@@ -19,14 +19,14 @@ The following is the criteria that a Provider and Requirer need to adhere to be 
 
 ### Provider
 
-- Is expected to provide a list of dns_domains and a list of dns_entries in the relation databag, each containing the domain, the status and optionally the description corresponding to the dns_domains and dns_entries requirested by the requirer.
-- Is expected to authenticate requests for dns_domains based on internal business rules/processes at the organisation where this charm is deployed.
+- Is expected to provide a list of dns_entries in the relation databag, each containing the domain, the status and optionally the description corresponding to the dns_entries requirested by the requirer.
+- Is expected to authenticate requests for dns_entries based on internal business rules/processes at the organisation where this charm is deployed.
 
 ### Requirer
 
-- Is expected to provide a list of dns_domains in the relation databag, each containing the domain it is requesting a DNS record for, the username and the password containing a juju secret for the provider to authenticate the request.
+- Is expected to provide a service_account user to authenticate so that the requests can be autheticated.
 - Is expected to provide a list of dns_entries mains in the relation databag, containing at least the dns-domain, the host-label and record-data. The dns-domain must be present in the list of dns_domains for authentication.
-- Is expected to authenticate requests for dns_domains based on internal business rules/processes at the organisation where this charm is deployed. The credentials need to be negotiated outside of the charm relation.
+
 
 ## Relation Data
 
@@ -39,17 +39,6 @@ Provider provides the result of the requirer request. It should be placed in the
 #### Example
 ```json
   "application-data": {
-    "dns_domains": [
-      {
-        "uuid": "550e8400-e29b-41d4-a716-446655440000",
-        "status": "invalid_credentials",
-        "description": "invalid_credentials"
-      },
-      {
-        "uuid": "550e8400-e29b-41d4-a716-446655440001",
-        "status": "approved"
-      }
-    ],
     "dns_entries": [
       {
         "uuid": "550e8400-e29b-41d4-a716-446655440002",
@@ -75,20 +64,10 @@ Requirer request the details of one or more DNS records. It should be placed in 
 
 ```json
   "application-data": {
-    "dns_domains": [
-      {
-        "uuid": "550e8400-e29b-41d4-a716-446655440000",
-        "domain": "cloud.canonical.com",
-        "username": "user1",
-        "password_id": "secret:123213123123123123123"
-      },
-      {
-        "uuid": "550e8400-e29b-41d4-a716-446655440001",
-        "domain": "staging.ubuntu.com",
-        "username": "user2",
-        "password_id": "secret:123213123123123123122"
-      }
-    ],
+    "service_account": {
+      "username": "user1",
+      "password_id": "secret:123213123123123123123" 
+    },
     "dns_entries": [
       {
         "uuid": "550e8400-e29b-41d4-a716-446655440002",

--- a/interfaces/dns_record/v0/README.md
+++ b/interfaces/dns_record/v0/README.md
@@ -24,7 +24,7 @@ The following is the criteria that a Provider and Requirer need to adhere to be 
 
 ### Requirer
 
-- Is expected to provide a service_account user to authenticate so that the requests can be autheticated.
+- Is expected to provide a service_account for the provider to authenticate the requests.
 - Is expected to provide a list of dns_entries mains in the relation databag, containing at least the dns-domain, the host-label and record-data. The dns-domain must be present in the list of dns_domains for authentication.
 
 
@@ -64,10 +64,7 @@ Requirer request the details of one or more DNS records. It should be placed in 
 
 ```json
   "application-data": {
-    "service_account": {
-      "username": "user1",
-      "password_id": "secret:123213123123123123123" 
-    },
+    "service_account": "secret:123213123123123123123",
     "dns_entries": [
       {
         "uuid": "550e8400-e29b-41d4-a716-446655440002",

--- a/interfaces/dns_record/v0/schema.py
+++ b/interfaces/dns_record/v0/schema.py
@@ -9,20 +9,10 @@ Examples:
     RequirerSchema:
         unit: <empty>
         app: {
-          "dns_domains": [
-            {
-              "uuid": "550e8400-e29b-41d4-a716-446655440000",
-              "domain": "cloud.canonical.com",
-              "username": "user1",
-              "password_id": "secret:123213123123123123123"
-            },
-            {
-              "uuid": "550e8400-e29b-41d4-a716-446655440001",
-              "domain": "staging.ubuntu.com",
-              "username": "user2",
-              "password_id": "secret:123213123123123123123"
-            }
-          ],
+          "service_account":  {
+            "username": "user1",
+            "password_id": "secret:123213123123123123123"
+          },
           "dns_entries": [
             {
               "uuid": "550e8400-e29b-41d4-a716-446655440002",
@@ -45,17 +35,6 @@ Examples:
     ProviderSchema:
         unit: <empty>
         app: {
-          "dns_domains": [
-            {
-              "uuid": "550e8400-e29b-41d4-a716-446655440000",
-              "status": "invalid_credentials",
-              "description": "invalid_credentials"
-            },
-            {
-              "uuid": "550e8400-e29b-41d4-a716-446655440001",
-              "status": "approved"
-            }
-          ],
           "dns_entries": [
             {
               "uuid": "550e8400-e29b-41d4-a716-446655440002",
@@ -140,23 +119,13 @@ class DnsProviderData(BaseModel):
 
 class DNSRecordProvider(BaseModel):
     """List statuses for the DNS records informed by the requirer."""
-    dns_domains: List[DnsProviderData] = Field(
-        name="DNS domains",
-        description="List statuses for the domains requested by the requirer."
-    )
     dns_entries: List[DnsProviderData] = Field(
         name="DNS entries",
         description="List of statuses for the DNS records requested by the requirer."
     )
 
 
-class RequirerDomains(BaseModel):
-    domain: str = Field(
-        min_length=1,
-        name="Domain",
-        description="Domain name for the provider to manage.",
-        examples=["cloud.canonical.com", "staging.ubuntu.com"]
-    )
+class ServiceAccount(BaseModel):
     username: str = Field(
         name="Username",
         description="Username for authentication.",
@@ -166,11 +135,6 @@ class RequirerDomains(BaseModel):
         name="Password",
         description="Juju secret containing the user password.",
         examples=["secret:123213123123123123123"],
-    )
-    uuid: UUID = Field(
-        name="UUID",
-        description="UUID for this domain.",
-        examples="550e8400-e29b-41d4-a716-446655440000"
     )
 
 
@@ -219,9 +183,9 @@ class RequirerEntries(BaseModel):
 
 class DNSRecordRequirer(BaseModel):
     """List of domains for the provider to manage."""
-    dns_domains: List[RequirerDomains] = Field(
-        name="DNS domains",
-        description="List of domains for the provider to manage."
+    service_account: ServiceAccount = Field(
+        name="Service account",
+        description="Service account for authentication."
     )
     dns_entries: List[RequirerEntries] = Field(
         name="DNS entries",

--- a/interfaces/dns_record/v0/schema.py
+++ b/interfaces/dns_record/v0/schema.py
@@ -9,10 +9,7 @@ Examples:
     RequirerSchema:
         unit: <empty>
         app: {
-          "service_account":  {
-            "username": "user1",
-            "password_id": "secret:123213123123123123123"
-          },
+          "service_account": "secret:123213123123123123123",
           "dns_entries": [
             {
               "uuid": "550e8400-e29b-41d4-a716-446655440002",
@@ -113,7 +110,7 @@ class DnsProviderData(BaseModel):
         default=None,
         name="Status description",
         description="Status description.",
-        examples=["incorrect username and password"]
+        examples=["incorrect credentials"]
     )
 
 
@@ -122,19 +119,6 @@ class DNSRecordProvider(BaseModel):
     dns_entries: List[DnsProviderData] = Field(
         name="DNS entries",
         description="List of statuses for the DNS records requested by the requirer."
-    )
-
-
-class ServiceAccount(BaseModel):
-    username: str = Field(
-        name="Username",
-        description="Username for authentication.",
-        examples=["user1", "user2"],
-    )
-    password_id: str = Field(
-        name="Password",
-        description="Juju secret containing the user password.",
-        examples=["secret:123213123123123123123"],
     )
 
 
@@ -183,9 +167,10 @@ class RequirerEntries(BaseModel):
 
 class DNSRecordRequirer(BaseModel):
     """List of domains for the provider to manage."""
-    service_account: ServiceAccount = Field(
+    service_account: str = Field(
         name="Service account",
-        description="Service account for authentication."
+        description="Service account for authentication.",
+        examples="secret:123213123123123123123"
     )
     dns_entries: List[RequirerEntries] = Field(
         name="DNS entries",


### PR DESCRIPTION
Follow up #145 

Change the requirer and provider databags. Remove the dns-domains entry for both and send instead a service-account entry for authenticating the requirer's request as a whole.

No charms implementing the relation have been released yet