### PR TITLE
update prometheus_scrape for pydantic v2

### DIFF
--- a/docs/json_schemas/prometheus_scrape/v0/provider.json
+++ b/docs/json_schemas/prometheus_scrape/v0/provider.json
@@ -150,6 +150,7 @@
               "type": "null"
             }
           ],
+          "default": null,
           "description": "Path for metrics scraping.",
           "title": "Metrics Path"
         },
@@ -163,7 +164,6 @@
         }
       },
       "required": [
-        "metrics_path",
         "static_configs"
       ],
       "title": "ScrapeJobModel",

--- a/interfaces/prometheus_scrape/v0/schema.py
+++ b/interfaces/prometheus_scrape/v0/schema.py
@@ -105,7 +105,9 @@ class ScrapeJobModel(BaseModel):
         description="Name of the Prometheus scrape job, each job must be given a unique name &  should be a fixed string (e.g. hardcoded literal)",
         default=None,
     )
-    metrics_path: Optional[str] = Field(description="Path for metrics scraping.")
+    metrics_path: Optional[str] = Field(
+        description="Path for metrics scraping.", default=None
+    )
     static_configs: List[ScrapeStaticConfigModel] = Field(
         description="List of static configurations for scrape targets."
     )


### PR DESCRIPTION
The prometheus_scrape interface has an optional `metrics_path` data field.  In pydantic v1, this can be defined by simply setting `metrics_path: Optional[str] = ...`` in the class definition, however pydantic v2 now requires the field default to be set for any optional parameters.  This means that any application using this interface with pydantic v2 was required to specify metrics_path.

This commit fixes this issue, restoring metrics_path to being optional for pydantic v2.  See [this thread](https://github.com/canonical/cos-proxy-operator/issues/140#issuecomment-2161371827) for more details.

This fix is demonstrated working in [this pr](https://github.com/canonical/cos-proxy-operator/pull/141), specifically [this commit](https://github.com/canonical/cos-proxy-operator/pull/141/commits/0aa847666703eaaf9835b20bbd4ccc844c6fc395) which bumps to the modified schema and now passes scenario tests the previously failed.  