### PR TITLE
feat: Support for wrap TTL on vault_kv interface

### DIFF
--- a/docs/json_schemas/vault_kv/v0/provider.json
+++ b/docs/json_schemas/vault_kv/v0/provider.json
@@ -30,7 +30,7 @@
             },
             "type": "object"
           },
-          "description": "Mapping of unit name and credentials for that unit. Credentials are a juju secret containing a 'role-id' and a 'role-secret-id'.",
+          "description": "Mapping of unit name and credentials for that unit. Credentials are a juju secret containing a 'role-id' and a 'role-secret-id'. In case of wrap_ttl being requested, 'role-secret-id' will be empty and 'wrapping-token' will contain the role-secret-id as a response-wrapping token.",
           "title": "Credentials",
           "type": "string"
         }

--- a/docs/json_schemas/vault_kv/v0/requirer.json
+++ b/docs/json_schemas/vault_kv/v0/requirer.json
@@ -6,6 +6,19 @@
           "description": "Suffix to append to the mount name to get the KV mount.",
           "title": "Mount Suffix",
           "type": "string"
+        },
+        "wrap_ttl": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to request approle secret_id as a response-wrapping token with a certain TTL. If not set, no wrapping will be made to secret_id. Otherwise, wrap_ttl specifies the duration of seconds before the expiration of the response-wrapping token.",
+          "title": "Wrap TTL"
         }
       },
       "required": [

--- a/interfaces/vault_kv/v0/README.md
+++ b/interfaces/vault_kv/v0/README.md
@@ -8,7 +8,7 @@ Some charms require a secure key value store. This relation interface describes 
 
 ```mermaid
 flowchart TD
-    Requirer -- mount_suffix, nonce, egress_subnet --> Provider
+    Requirer -- mount_suffix, nonce, egress_subnet, [wrap_ttl] --> Provider
     Provider -- vault_url, ca_certificate, mount, credentials --> Requirer
 ```
 
@@ -24,7 +24,7 @@ Provider expectations
 - Is expected to provide a ca certificate used to validate the vault server's certificate.
 - Is expected to provide a key value mount, the mount name shall respect the following pattern: `charm-<requirer app>-<requirer provided suffix>`
 - Is expected to create an approle restricted to the requiring unit's egress subnet.
-- Is expected to create a Juju secret containing a role-id and role-secret-id for each unit.
+- Is expected to create a Juju secret containing a role-id and role-secret-id for each unit. If `wrap_ttl` is requested by the Requirer, the Provider is expected to return a response-wrapping token instead of the `role-secret-id`. The response-wrapping token must contain the response of the POST `/auth/approle/role/:role_name/secret-id` API call. More information about wrapping tokens can be found in Vault [docs](https://developer.hashicorp.com/vault/docs/concepts/response-wrapping).
 - Is expected to provide the Juju secret ID in the relation data, identified by the unit's nonce.
 - Is expected to have out of date credentials when requirer unit's identity change, for some unspecified amount of time
   until new credentials have been generated. For example, during an upgrade-charm event.
@@ -37,6 +37,7 @@ Requirer expectations
 - Is expected to provide an egress subnet for each unit requiring access to the vault key value store.
   The unit's egress_subnet shall be used to restrict access to the secret backend.
 - Is expected to provide a nonce, i.e. a string uniquely identifying the unit.
+- Is expected to optionally provide a `wrap_ttl` to request the `role-secret-id` being returned as a response-wrapping token with desired TTL.
 
 ## Relation Data
 

--- a/interfaces/vault_kv/v0/schema.py
+++ b/interfaces/vault_kv/v0/schema.py
@@ -5,7 +5,7 @@ It must expose two interfaces.schema_base.DataBagSchema subclasses called:
 - RequirerSchema
 """
 
-from typing import Mapping
+from typing import Mapping, Optional
 
 from pydantic import BaseModel, Field, Json
 
@@ -27,6 +27,8 @@ class VaultKvProviderSchema(BaseModel):
         description=(
             "Mapping of unit name and credentials for that unit."
             " Credentials are a juju secret containing a 'role-id' and a 'role-secret-id'."
+            " In case of wrap_ttl being requested, 'role-secret-id' will be empty and"
+            " 'wrapping-token' will contain the role-secret-id as a response-wrapping token."
         )
     )
 
@@ -34,6 +36,15 @@ class VaultKvProviderSchema(BaseModel):
 class AppVaultKvRequirerSchema(BaseModel):
     mount_suffix: str = Field(
         description="Suffix to append to the mount name to get the KV mount."
+    )
+    wrap_ttl: Optional[int] = Field(
+        default=None,
+        title="Wrap TTL",
+        description=(
+            "Whether to request approle secret_id as a response-wrapping token with a certain TTL."
+            " If not set, no wrapping will be made to secret_id. Otherwise, wrap_ttl specifies"
+            " the duration of seconds before the expiration of the response-wrapping token."
+        )
     )
 
 


### PR DESCRIPTION
This PR enables the usage of wrapping tokens by the Requirer part of vault_kv interface, as something optional.

This PR will enable `vault_kv` integration with charms that require a wrapping token instead of the role secret ID, like `maas-region`. MAAS can be integrated with Vault by providing approle details, as described in the relevant docs [section](https://maas.io/docs/how-to-integrate-vault).