### PR TITLE
Use `ruff check`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ deps =
 commands =
     black --check {[vars]all_path}
     isort --profile black --check-only {[vars]all_path}
-    ruff {[vars]all_path}
+    ruff check {[vars]all_path}
 
 
 [testenv:fmt]


### PR DESCRIPTION
`ruff <path>` is deprecated