### PR TITLE
`tempo_cluster` interface

### DIFF
--- a/interfaces/tempo_cluster/v0/README.md
+++ b/interfaces/tempo_cluster/v0/README.md
@@ -1,0 +1,59 @@
+# `tempo_cluster`
+
+## Usage
+
+`tempo_cluster` is an interface meant to exchange cluster configuration in distributed Tempo deployments.
+Multiple [Tempo worker](https://github.com/canonical/tempo-worker-k8s-operator) applications can relate to a [Tempo coordinator](https://github.com/canonical/tempo-coordinator-k8s-operator) application over the `tempo_cluster` interface, and send their role and topology, in order to join the cluster.
+The coordinator will use the same relation to convey to the workers back the configuration that they must run with.
+
+## Direction
+
+This interface implements a provider/requirer pattern. The coordinator charm is the provider of the relation, the worker charm is the requirer. Information flows back and forth: first the requirer shares some data necessary for the coordinator to know the role of the worker, then the provider replies back with the configuration it should run with. 
+
+```mermaid
+flowchart TD
+    Requirer -- Role, JujuTopology --> Provider
+    Provider -- Config --> Requirer
+```
+
+## Behavior
+
+This is what is expected of the providers and the requirers of this interface:
+
+### Provider
+The provider is expected to...
+- update the gossip rings in all configurations with the addresses of all worker units that are joining the cluster (regardless of their role).
+- share the exact same configuration to all nodes, regardless of the role they declare, via application databg.
+
+### Requirer
+The requirer application is expected to...
+- publish its role as soon as possible via application databag.  
+Each requirer unit is expected to...
+- publish its address and JujuTopology as soon as possible, via unit databag.
+
+## Relation Data
+
+Describe the contents of the databags, and provide schemas for them.
+
+[\[Pydantic Schema\]](./schema.py)
+
+#### Example
+Provide a yaml/json example of a valid databag state (for the whole relation).
+```yaml
+provider:
+  app: 
+    config: 
+      # <a very large chunk of yaml>
+  unit: {}
+  
+requirer:
+  app: 
+    role: receiver
+  unit: 
+   juju_topology: 
+     model: "mymodel", 
+     model_uuid: "1231234120941234", 
+     application: "tempo-receiver", 
+     charm_name: "tempo-worker-k8s", 
+     unit: "tempo-receiver/2", 
+```

--- a/interfaces/tempo_cluster/v0/interface.yaml
+++ b/interfaces/tempo_cluster/v0/interface.yaml
@@ -1,0 +1,12 @@
+name: tempo_cluster
+internal: true
+version: 0
+status: beta
+
+providers:
+  - name: tempo-coordinator-k8s
+    url: https://github.com/canonical/tempo-coordinator-k8s-operator
+
+requirers:
+  - name: tempo-worker-k8s
+    url: https://github.com/canonical/tempo-worker-k8s-operator

--- a/interfaces/tempo_cluster/v0/schema.py
+++ b/interfaces/tempo_cluster/v0/schema.py
@@ -1,0 +1,78 @@
+"""This file defines the schemas for the provider and requirer sides of this relation interface.
+
+It must expose two interfaces.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+"""
+from enum import Enum
+from typing import Optional, Dict, Any, Literal
+
+from interface_tester.schema_base import DataBagSchema
+from pydantic import BaseModel
+
+ReceiverProtocol = Literal[
+    "zipkin",
+    "otlp_grpc",
+    "otlp_http",
+]
+
+class TempoClusterProviderAppData(BaseModel):
+    """TempoClusterProviderAppData."""
+    tempo_config: Dict[str, Any]
+    loki_endpoints: Optional[Dict[str, str]] = None
+    ca_cert: Optional[str] = None
+    server_cert: Optional[str] = None
+    privkey_secret_id: Optional[str] = None
+    tempo_receiver: Optional[Dict[ReceiverProtocol, str]] = None
+
+
+class JujuTopology(BaseModel):
+    """JujuTopology as defined by cos-lib."""
+    model: str
+    model_uuid: str
+    application: str
+    charm_name: str
+    unit: str
+
+
+class TempoClusterRequirerUnitData(BaseModel):
+    """TempoClusterRequirerUnitData."""
+
+    juju_topology: JujuTopology
+    address: str
+
+
+class TempoRole(str, Enum):
+    """Tempo component role names.
+
+    References:
+     arch:
+      -> https://grafana.com/docs/tempo/latest/operations/architecture/
+     config:
+      -> https://grafana.com/docs/tempo/latest/configuration/#server
+    """
+    all = "all"  # default, meta-role. gets remapped to scalable-single-binary by the worker.
+
+    querier = "querier"
+    query_frontend = "query-frontend"
+    ingester = "ingester"
+    distributor = "distributor"
+    compactor = "compactor"
+    metrics_generator = "metrics-generator"
+
+
+class TempoClusterRequirerAppData(BaseModel):
+    """TempoClusterRequirerAppData."""
+
+    role: TempoRole
+
+
+class ProviderSchema(DataBagSchema):
+    """The schema for the provider side of this interface."""
+    app: TempoClusterProviderAppData
+
+
+class RequirerSchema(DataBagSchema):
+    """The schema for the requirer side of this interface."""
+    app: TempoClusterRequirerAppData
+    unit: TempoClusterRequirerUnitData


### PR DESCRIPTION
This PR adds a specification for the `tempo_cluster` internal interface used by the tempo-worker and tempo-coordinator charms to coordinate the cluster creation.

I set the status to `beta` as it is currently in use but the charms aren't released on stable yet, so it's subject to change but somewhat beyond `draft`.
I skipped the interface tests as this interface is purely internal, we don't expect third parties to be interested in validating their implementation of either side of the interface. Not sure whether this is the right thing to do, do let me know if not.
