### PR TITLE
[DPE-2278] Add connection string to uri field in schema

### DIFF
--- a/interfaces/postgresql_client/v0/README.md
+++ b/interfaces/postgresql_client/v0/README.md
@@ -32,6 +32,7 @@ If any side, Provider or Requirer doesn't support Juju Secrets, sensitive inform
 - Is expected to expose the Juju Secrets URI to the credentials through the `secret-user` field of the data bag.
 - Is expected to provide the `endpoints` field with the address of Primary, which can be used for Read/Write queries.
 - Is expected to provide the `database` field with the database that was actually created.
+- Is expected to provide the `uris` field with the connection string, in libpq's URI format, which can be used for direct connection to the db.
 - Is expected to provide optional `read-only-endpoints` field with a comma-separated list of hosts or one Kubernetes Service, which can be used for Read-only queries.
 - Is expected to provide the `version` field whenever database charm wants to communicate its database version.
 - Is expected to provide the CA chain in the `tls-ca` field of a Juju Secret, whenever the provider has TLS enabled (such as using the [TLS Certificates Operator](https://github.com/canonical/tls-certificates-operator)).

--- a/interfaces/postgresql_client/v0/schemas/provider.json
+++ b/interfaces/postgresql_client/v0/schemas/provider.json
@@ -53,6 +53,16 @@
                 "unit-1:port,unit-2:port"
             ]
         },
+        "uris": {
+            "$id": "#/properties/uris",
+            "title": "URIs",
+            "description": "A connection string in URI format used to connect to the database",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "postgresql://user:pass@host-1:port,host-2:port/mydb"
+            ]
+        },
         "read-only-endpoints": {
             "$id": "#/properties/read-only-endpoints",
             "title": "Read-Only Database Endpoints",


### PR DESCRIPTION
Adds new URI field, a libpg connection string, to the provider's side of postgresql relation.

Related to https://github.com/canonical/postgresql-k8s-operator/pull/545 and https://github.com/canonical/postgresql-operator/pull/527