### PR TITLE
fix sdcore_config relation interface documentation

### DIFF
--- a/docs/json_schemas/sdcore_config/v0/provider.json
+++ b/docs/json_schemas/sdcore_config/v0/provider.json
@@ -23,7 +23,7 @@
       "type": "object"
     }
   },
-  "description": "The schema for the provider side of the sdcore-config interface.",
+  "description": "The schema for the provider side of the sdcore_config interface.",
   "properties": {
     "unit": {
       "anyOf": [

--- a/docs/json_schemas/sdcore_config/v0/requirer.json
+++ b/docs/json_schemas/sdcore_config/v0/requirer.json
@@ -6,7 +6,7 @@
       "type": "object"
     }
   },
-  "description": "The schema for the requirer side of the sdcore-config interface.",
+  "description": "The schema for the requirer side of the sdcore_config interface.",
   "properties": {
     "unit": {
       "anyOf": [

--- a/interfaces/sdcore_config/v0/README.md
+++ b/interfaces/sdcore_config/v0/README.md
@@ -1,4 +1,4 @@
-# `sdcore-config`
+# `sdcore_config`
 
 ## Usage
 
@@ -6,7 +6,7 @@ Within SD-Core, the Webui URL needs to be known by other components for the conf
 
 Hence, SD-Core NF's need to connect to config server using Webui URL which is consist of Webui Operator hostname which equals to application name and a fixed GRPC port.
 
-The `sdcore-config` relation interface describes the expected behavior of any charm claiming to be able to provide or consume the Webui GRPC address.
+The `sdcore_config` relation interface describes the expected behavior of any charm claiming to be able to provide or consume the Webui GRPC address.
 
 In SD-Core network, the provider of this interface would be the Webui operator and the requirer of this interface would be the control plane NF's (AMF, SMF, AUSF, NRF, NSSF, UDM,  UDR, and PCF).
 
@@ -17,7 +17,7 @@ flowchart TD
     Provider -- url --> Requirer
 ```
 
-As with all Juju relations, the `sdcore-config` interface consists of two parties: a Provider and a Requirer.
+As with all Juju relations, the `sdcore_config` interface consists of two parties: a Provider and a Requirer.
 
 ## Behavior
 

--- a/interfaces/sdcore_config/v0/interface.yaml
+++ b/interfaces/sdcore_config/v0/interface.yaml
@@ -5,7 +5,24 @@ version: 0
 status: draft
 
 providers:
-  - name: sdcore-webui
-    url: https://github.com/canonical/sdcore-webui-k8s-operator
+  - name: sdcore-nms-k8s
+    url: https://github.com/canonical/sdcore-nms-k8s-operator
 
-requirers: []
+requirers:
+  - name: sdcore-amf-k8s
+    url: https://github.com/canonical/sdcore-amf-k8s-operator
+  - name: sdcore-ausfr-k8s
+    url: https://github.com/canonical/sdcore-ausf-k8s-operator
+  - name: sdcore-nrf-k8s
+    url: https://github.com/canonical/sdcore-nrf-k8s-operator
+  - name: sdcore-nssf-k8s
+    url: https://github.com/canonical/sdcore-nssf-k8s-operator
+  - name: sdcore-pcf-k8s
+    url: https://github.com/canonical/sdcore-pcf-k8s-operator
+  - name: sdcore-smf-k8s
+    url: https://github.com/canonical/sdcore-smf-k8s-operator
+  - name: sdcore-udm-k8s
+    url: https://github.com/canonical/sdcore-udm-k8s-operator
+  - name: sdcore-udr-k8s
+    url: https://github.com/canonical/sdcore-udr-k8s-operator
+

--- a/interfaces/sdcore_config/v0/schema.py
+++ b/interfaces/sdcore_config/v0/schema.py
@@ -1,4 +1,4 @@
-"""This file defines the schemas for the provider and requirer sides of the `sdcore-config` relation interface.
+"""This file defines the schemas for the provider and requirer sides of the `sdcore_config` relation interface.
 
 It must expose two interfaces.schema_base.DataBagSchema subclasses called:
 - ProviderSchema
@@ -27,9 +27,9 @@ class SdcoreConfigProviderAppData(BaseModel):
 
 
 class ProviderSchema(DataBagSchema):
-    """The schema for the provider side of the sdcore-config interface."""
+    """The schema for the provider side of the sdcore_config interface."""
     app: SdcoreConfigProviderAppData
 
 
 class RequirerSchema(DataBagSchema):
-    """The schema for the requirer side of the sdcore-config interface."""
+    """The schema for the requirer side of the sdcore_config interface."""


### PR DESCRIPTION
The `sdcore_config` relation interface was defined with an `_` not with a `-`. 

This PR:
- Aligns the documentation to the interface definition (use `_` instead of `-`) 
- Sets the NMS charm as provider
- Sets the AMF, SMF, AUSF, NRF, NSSF, UDM, UDR, and PCF as requirers.