### PR TITLE
Renames egress_subnet to egress_subnets and changes its type to array

### DIFF
--- a/docs/json_schemas/vault_kv/v0/requirer.json
+++ b/docs/json_schemas/vault_kv/v0/requirer.json
@@ -30,7 +30,7 @@
     "UnitVaultKvRequirerSchema": {
       "properties": {
         "egress_subnet": {
-          "description": "Egress subnet to use, in CIDR notation.",
+          "description": "A string of egress subnets separated by commas, in CIDR notation.",
           "title": "Egress Subnet",
           "type": "string"
         },

--- a/interfaces/vault_kv/v0/README.md
+++ b/interfaces/vault_kv/v0/README.md
@@ -83,7 +83,7 @@ requirer:
     mount_suffix: secrets
   unit:
     barbican-0:
-      egress_subnet: "10.1.166.206/32, 10.1.1.0/32"
+      egress_subnet: "10.1.166.206/32,10.1.1.0/32"
       nonce: 3081279da89c48a32923473c2c587019
     barbican-1:
       egress_subnet: "10.1.166.230/32"

--- a/interfaces/vault_kv/v0/README.md
+++ b/interfaces/vault_kv/v0/README.md
@@ -36,7 +36,7 @@ Requirer expectations
 - Is expected to provide a mount suffix.
 - Is expected to provide the egress subnets for each unit requiring access to the vault key value store.
   The unit's egress_subnet shall be used to restrict access to the secret backend.
-  egress_subnet should contain all of the desired addresses in a string separated by commas.
+  The egress_subnet field should contain a string of all desired addresses separated by commas, using CIDR notation.
 - Is expected to provide a nonce, i.e. a string uniquely identifying the unit.
 - Is expected to optionally provide a `wrap_ttl` to request the `role-secret-id` being returned as a response-wrapping token with desired TTL.
 

--- a/interfaces/vault_kv/v0/README.md
+++ b/interfaces/vault_kv/v0/README.md
@@ -34,8 +34,9 @@ Provider expectations
 Requirer expectations
 
 - Is expected to provide a mount suffix.
-- Is expected to provide an egress subnet for each unit requiring access to the vault key value store.
+- Is expected to provide the egress subnets for each unit requiring access to the vault key value store.
   The unit's egress_subnet shall be used to restrict access to the secret backend.
+  egress_subnet should contain all of the desired addresses in a string separated by commas.
 - Is expected to provide a nonce, i.e. a string uniquely identifying the unit.
 - Is expected to optionally provide a `wrap_ttl` to request the `role-secret-id` being returned as a response-wrapping token with desired TTL.
 
@@ -82,9 +83,9 @@ requirer:
     mount_suffix: secrets
   unit:
     barbican-0:
-      egress_subnet: 10.1.166.206/32
+      egress_subnet: "10.1.166.206/32, 10.1.1.0/32"
       nonce: 3081279da89c48a32923473c2c587019
     barbican-1:
-      egress_subnet: 10.1.166.230/32
+      egress_subnet: "10.1.166.230/32"
       nonce: b49e6098f245344f1035c3aa0e0c9181
 ```

--- a/interfaces/vault_kv/v0/schema.py
+++ b/interfaces/vault_kv/v0/schema.py
@@ -49,7 +49,7 @@ class AppVaultKvRequirerSchema(BaseModel):
 
 
 class UnitVaultKvRequirerSchema(BaseModel):
-    egress_subnet: str = Field(description="Egress subnets to use separated by commas, in CIDR notation.")
+    egress_subnet: str = Field(description="A string of egress subnets separated by commas, in CIDR notation.")
     nonce: str = Field(
         description=(
             "Uniquely identifying value for this unit."

--- a/interfaces/vault_kv/v0/schema.py
+++ b/interfaces/vault_kv/v0/schema.py
@@ -49,7 +49,7 @@ class AppVaultKvRequirerSchema(BaseModel):
 
 
 class UnitVaultKvRequirerSchema(BaseModel):
-    egress_subnet: str = Field(description="Egress subnet to use, in CIDR notation.")
+    egress_subnet: str = Field(description="Egress subnets to use separated by commas, in CIDR notation.")
     nonce: str = Field(
         description=(
             "Uniquely identifying value for this unit."


### PR DESCRIPTION
This requirer must provide a list of the IP addresses that it wants Vault to configure the authentication credentials with.
This should allow the requirer to be implemented in a way that allows providing different addresses so it works in both cases when it is deployed on the same model with Vault and when it is deployed in a cross model setup.