### PR TITLE
feat: Adds the fiveg_f1 interface

### DIFF
--- a/docs/json_schemas/fiveg_f1/v0/provider.json
+++ b/docs/json_schemas/fiveg_f1/v0/provider.json
@@ -1,0 +1,58 @@
+{
+  "$defs": {
+    "BaseModel": {
+      "properties": {},
+      "title": "BaseModel",
+      "type": "object"
+    },
+    "FivegF1ProviderAppData": {
+      "properties": {
+        "f1_ip_address": {
+          "description": "IPv4 address of the network interface used for F1 traffic",
+          "examples": [
+            "192.168.70.132"
+          ],
+          "format": "ipvanyaddress",
+          "title": "F1 Ip Address",
+          "type": "string"
+        },
+        "f1_port": {
+          "description": "Number of the port used for F1 traffic",
+          "examples": [
+            2153
+          ],
+          "title": "F1 Port",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "f1_ip_address",
+        "f1_port"
+      ],
+      "title": "FivegF1ProviderAppData",
+      "type": "object"
+    }
+  },
+  "description": "Provider schema for fiveg_f1.",
+  "properties": {
+    "unit": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BaseModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "app": {
+      "$ref": "#/$defs/FivegF1ProviderAppData"
+    }
+  },
+  "required": [
+    "app"
+  ],
+  "title": "ProviderSchema",
+  "type": "object"
+}

--- a/docs/json_schemas/fiveg_f1/v0/requirer.json
+++ b/docs/json_schemas/fiveg_f1/v0/requirer.json
@@ -1,0 +1,48 @@
+{
+  "$defs": {
+    "BaseModel": {
+      "properties": {},
+      "title": "BaseModel",
+      "type": "object"
+    },
+    "FivegF1RequirerAppData": {
+      "properties": {
+        "f1_port": {
+          "description": "Number of the port used for F1 traffic",
+          "examples": [
+            2153
+          ],
+          "title": "F1 Port",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "f1_port"
+      ],
+      "title": "FivegF1RequirerAppData",
+      "type": "object"
+    }
+  },
+  "description": "Requirer schema for fiveg_f1.",
+  "properties": {
+    "unit": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BaseModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "app": {
+      "$ref": "#/$defs/FivegF1RequirerAppData"
+    }
+  },
+  "required": [
+    "app"
+  ],
+  "title": "RequirerSchema",
+  "type": "object"
+}

--- a/interfaces/fiveg_f1/v0/README.md
+++ b/interfaces/fiveg_f1/v0/README.md
@@ -1,0 +1,50 @@
+# `fiveg_f1`
+
+## Usage
+
+Within 5G RAN (Radio Access Network) architecture, the Functional Split (F1) interface facilitates communication between the Central Unit (CU) and the Distributed Unit (DU).
+
+This relation interface describes the expected behavior of any charm claiming to be able to provide or consume information on connectivity over the F1 interface.
+
+## Direction
+
+```mermaid
+flowchart TD
+    Provider -- ip_address, port --> Requirer
+    Requirer -- port --> Provider
+```
+
+As with all Juju relations, the `fiveg_f1` interface consists of two parties: a Provider and a Requirer.
+
+## Behavior
+
+Both the Requirer and the Provider need to adhere to criteria to be considered compatible with the interface.
+
+### Provider
+
+- Is expected to provide the IP address and port of the CU's F1 interface.
+
+### Requirer
+
+- Is expected to use the IP address and the port passed by the provider to establish communication over the F1 interface.
+- Is expected to provider the number of the port which will handle communication over the F1 interface.
+
+## Relation Data
+
+[\[Pydantic Schema\]](./schema.py)
+
+#### Example
+
+```yaml
+provider:
+  app: {
+    "f1_ip_address": "192.168.70.132",
+    "f1_port": 2153
+  }
+  unit: {}
+requirer:
+  app: {
+    "f1_port": 2153
+  }
+  unit: {}
+```

--- a/interfaces/fiveg_f1/v0/interface.yaml
+++ b/interfaces/fiveg_f1/v0/interface.yaml
@@ -1,0 +1,12 @@
+name: fiveg_f1
+internal: true
+
+version: 0
+status: draft
+
+providers:
+  - name: oai-ran-cu-k8s
+    url: https://github.com/canonical/oai-ran-cu-k8s
+requirers:
+  - name: oai-ran-du-k8s
+    url: https://github.com/canonical/oai-ran-du-k8s

--- a/interfaces/fiveg_f1/v0/schema.py
+++ b/interfaces/fiveg_f1/v0/schema.py
@@ -1,0 +1,49 @@
+"""This file defines the schemas for the provider and requirer sides of the `fiveg_f1` interface.
+It exposes two interface_tester.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {
+            "f1_ip_address": "192.168.70.132",
+            "f1_port": 2153
+        }
+    RequirerSchema:
+        unit: <empty>
+        app:  {
+            "f1_port": 2153
+        }
+"""
+
+from pydantic import BaseModel, IPvAnyAddress, Field
+
+from interface_tester.schema_base import DataBagSchema
+
+
+class FivegF1ProviderAppData(BaseModel):
+    f1_ip_address: IPvAnyAddress = Field(
+        description="IPv4 address of the network interface used for F1 traffic",
+        examples=["192.168.70.132"]
+    )
+    f1_port: int = Field(
+        description="Number of the port used for F1 traffic",
+        examples=[2153]
+    )
+
+
+class FivegF1RequirerAppData(BaseModel):
+    f1_port: int = Field(
+        description="Number of the port used for F1 traffic",
+        examples=[2153]
+    )
+
+
+class ProviderSchema(DataBagSchema):
+    """Provider schema for fiveg_f1."""
+    app: FivegF1ProviderAppData
+
+
+class RequirerSchema(DataBagSchema):
+    """Requirer schema for fiveg_f1."""
+    app: FivegF1RequirerAppData


### PR DESCRIPTION
This PR adds definition of the `fiveg_f1` interface. 

In the 5G Radio Access Network architecture the `F1` interface is used to establish communication between the Central Unit (CU) and the Distributed Unit (DU) which are main building blocks of the gNodeB (the 5G base station). 