### PR TITLE
Subordinated router scale up

### DIFF
--- a/interfaces/postgresql_client/v0/README.md
+++ b/interfaces/postgresql_client/v0/README.md
@@ -13,8 +13,8 @@ Some Providers may be subordinate charms aimed at providing mainly a local servi
 
 ```mermaid
 flowchart TD
-    Requirer -- database, \nextra-user-roles, \nrequested-secrets\nexternal-node-connectivity --> Provider
-    Provider -- database, \nendpoints, \nsecret-user --> Requirer
+    Requirer -- database, \nextra-user-roles, \nrequested-secrets, \nexternal-node-connectivity --> Provider
+    Provider -- database, \nendpoints, \nsecret-user, \nsubordinated, \nstate--> Requirer
 ```
 
 As with all Juju relations, the `database` interface consists of two parties: a Provider (database charm), and a Requirer (application charm). The Requirer will be expected to provide a database name, and the Provider will provide new unique credentials (along with other optional fields), which can be used to access the actual database cluster.
@@ -38,7 +38,8 @@ If any side, Provider or Requirer doesn't support Juju Secrets, sensitive inform
 - Is expected to provide the CA chain in the `tls-ca` field of a Juju Secret, whenever the provider has TLS enabled (such as using the [TLS Certificates Operator](https://github.com/canonical/tls-certificates-operator)).
 - Is expected to share the TLS Juju Secret URI through the `secret-tls` field of the databag.
 - If the Requirer asks for additional secrets (via `requested-secrets`, see below) other than those stored in the `user` and `tls` secrets, Provider is expected to define a `secret-extra` field holding the URI of the Juju Secret containing all additional secret fields.
-- Is expected to express (via `external-node-connectivity`) whether external connectivity requests are to respected or not, in case the charm is capable of such.
+- Is expected to express (via `external-node-connectivity`) whether external connectivity requests are to be respected or not, in case the charm is capable of such.
+- May require delays (via `subordinated`) to provide service on Requirer scale up. If so, it is expected to set unit level `state` data when it is `ready` to serve.
 
 ### Requirer
 
@@ -49,6 +50,7 @@ If any side, Provider or Requirer doesn't support Juju Secrets, sensitive inform
 - Is expected to allow multiple different Juju applications to access the same database name.
 - Is expected to add any `extra-user-roles` provided by the Requirer to the created user (e.g. `extra-user-roles=admin`).
 - Is expected to tolerate that the Provider may ignore the `database` field in some cases and instead use the database name received.
+- Is expected to respect the `subordinated` flag when scaling up and start emitting events only once unit level `state` is `ready`.
 - May require external connectivity (via `external-node-connectivity`).
 
 ## Relation Data

--- a/interfaces/postgresql_client/v0/schemas/provider.json
+++ b/interfaces/postgresql_client/v0/schemas/provider.json
@@ -82,6 +82,26 @@
             "examples": [
                 "8.0.27-18"
             ]
+        },
+        "subordinated": {
+            "$id": "#/properties/subordinated",
+            "title": "Subordinated",
+            "description": "Indicates that the provider should check the unit state when scaling up",
+            "type": "string",
+            "default": "true",
+            "examples": [
+                "true"
+            ]
+        },
+        "state": {
+            "$id": "#/properties/state",
+            "title": "State",
+            "description": "Unit level data to indicate that a subordinate unit is ready to serve",
+            "type": "string",
+            "default": "ready",
+            "examples": [
+                "ready"
+            ]
         }
     },
     "examples": [{


### PR DESCRIPTION
Adds `subordinated` app and `state` unit level flags to the postgresql_client interface. Those flags are needed to indicate when a subordinated Pgbouncer VM charm is ready to accept connections.

Implementation PR: https://github.com/canonical/data-platform-libs/pull/180
Specification: DA104