### PR TITLE
Add saml relation interface v1

### DIFF
--- a/docs/json_schemas/saml/v1/provider.json
+++ b/docs/json_schemas/saml/v1/provider.json
@@ -1,0 +1,226 @@
+{
+  "$defs": {
+    "BaseModel": {
+      "properties": {},
+      "title": "BaseModel",
+      "type": "object"
+    },
+    "SamlProviderData": {
+      "properties": {
+        "metadata": {
+          "description": "IdP's metadata.",
+          "examples": [
+            "<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" entityID=\"https://login.ubuntu.com\">\n            <md:IDPSSODescriptor protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">\n            <md:KeyDescriptor use=\"signing\">\n                <ds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\">\n                    <ds:X509Data>\n                        <ds:X509Certificate>MIICjzCCAfigAwIBAgIJALNN/vxaR1hyMA0GCSqGSIb3DQEBBQUAMDoxCzAJBgNVBAYTAkdCMRMwEQYDVQQIEwpTb21lLVN0YXRlMRYwFAYDVQQKEw1DYW5vbmljYWwgTHRkMB4XDTEyMDgxMDEyNDE0OFoXDTEzMDgxMDEyNDE0OFowOjELMAkGA1UEBhMCR0IxEzARBgNVBAgTClNvbWUtU3RhdGUxFjAUBgNVBAoTDUNhbm9uaWNhbCBMdGQwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMM4pmIxkv419q8zj5EojK57y6plU/+k3apX6w1PgAYeI0zhNuud/tiqKVQEDyZ6W7HNeGtWSh5rewy8c07BShcHG5Y8ibzBdIibGs5k6gvtmsRiXDE/F39+RrPSW18beHhEuoVJM9RANp3MYMOK11SiClSiGo+NfBKFuoqNX3UjAgMBAAGjgZwwgZkwHQYDVR0OBBYEFH/no88pbywRnW6Fz+B4lQ04w/86MGoGA1UdIwRjMGGAFH/no88pbywRnW6Fz+B4lQ04w/86oT6kPDA6MQswCQYDVQQGEwJHQjETMBEGA1UECBMKU29tZS1TdGF0ZTEWMBQGA1UEChMNQ2Fub25pY2FsIEx0ZIIJALNN/vxaR1hyMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEArTGbZ1rg++aBxnNuJ7eho62JKKtRW5O+kMBvBLWi7fKck5uXDE6d7Jv6hUy/gwUZV7r5kuPwRlw3Pu6AX4R60UsQuVG1/VVVI7nu32iCkXx5Vzq446IkVRdk/QOda1dRyq0oaifUUhJfwVFSsm95ENDFdGqD0raj7g77ajcBMf8=</ds:X509Certificate>\n                    </ds:X509Data>\n                </ds:KeyInfo>\n            </md:KeyDescriptor>\n            <md:KeyDescriptor use=\"encryption\">\n                <ds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\">\n                    <ds:X509Data>\n                        <ds:X509Certificate>MIICjzCCAfigAwIBAgIJALNN/vxaR1hyMA0GCSqGSIb3DQEBBQUAMDoxCzAJBgNVBAYTAkdCMRMwEQYDVQQIEwpTb21lLVN0YXRlMRYwFAYDVQQKEw1DYW5vbmljYWwgTHRkMB4XDTEyMDgxMDEyNDE0OFoXDTEzMDgxMDEyNDE0OFowOjELMAkGA1UEBhMCR0IxEzARBgNVBAgTClNvbWUtU3RhdGUxFjAUBgNVBAoTDUNhbm9uaWNhbCBMdGQwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMM4pmIxkv419q8zj5EojK57y6plU/+k3apX6w1PgAYeI0zhNuud/tiqKVQEDyZ6W7HNeGtWSh5rewy8c07BShcHG5Y8ibzBdIibGs5k6gvtmsRiXDE/F39+RrPSW18beHhEuoVJM9RANp3MYMOK11SiClSiGo+NfBKFuoqNX3UjAgMBAAGjgZwwgZkwHQYDVR0OBBYEFH/no88pbywRnW6Fz+B4lQ04w/86MGoGA1UdIwRjMGGAFH/no88pbywRnW6Fz+B4lQ04w/86oT6kPDA6MQswCQYDVQQGEwJHQjETMBEGA1UECBMKU29tZS1TdGF0ZTEWMBQGA1UEChMNQ2Fub25pY2FsIEx0ZIIJALNN/vxaR1hyMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEArTGbZ1rg++aBxnNuJ7eho62JKKtRW5O+kMBvBLWi7fKck5uXDE6d7Jv6hUy/gwUZV7r5kuPwRlw3Pu6AX4R60UsQuVG1/VVVI7nu32iCkXx5Vzq446IkVRdk/QOda1dRyq0oaifUUhJfwVFSsm95ENDFdGqD0raj7g77ajcBMf8=</ds:X509Certificate>\n                    </ds:X509Data>\n                </ds:KeyInfo>\n            </md:KeyDescriptor>\n            <md:SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://login.ubuntu.com/+logout\"/>\n            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:email</md:NameIDFormat>\n            <md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://login.ubuntu.com/saml/\"/>\n            </md:IDPSSODescriptor>\n        </md:EntityDescriptor>"
+          ],
+          "title": "Metadata",
+          "type": "string"
+        },
+        "metadata_url": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "URL to the IdP's metadata.",
+          "examples": [
+            "https://login.ubuntu.com/saml/metadata"
+          ],
+          "title": "Metadata URL"
+        },
+        "entity_id": {
+          "description": "Identifier of the IdP entity.",
+          "examples": [
+            "https://login.ubuntu.com"
+          ],
+          "format": "uri",
+          "minLength": 1,
+          "title": "Entity ID",
+          "type": "string"
+        },
+        "single_sign_on_service_redirect_url": {
+          "description": "URL target of the IdP where the Authentication REDIRECT Request Message will be sent.",
+          "examples": [
+            "https://login.ubuntu.com/saml/"
+          ],
+          "format": "uri",
+          "minLength": 1,
+          "title": "SSO REDIRECT URL",
+          "type": "string"
+        },
+        "single_sign_on_service_redirect_binding": {
+          "description": "SAML protocol binding to be used when returning the REDIRECT <Response> message.",
+          "examples": [
+            "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+          ],
+          "title": "SSO REDIRECT binding",
+          "type": "string"
+        },
+        "single_sign_on_service_post_url": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "URL target of the IdP where the Authentication POST Request Message will be sent.",
+          "examples": [
+            "https://login.ubuntu.com/saml/"
+          ],
+          "title": "SSO POST response URL"
+        },
+        "single_sign_on_service_post_binding": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "SAML protocol binding to be used when returning the POST <Response> message.",
+          "examples": [
+            "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Post"
+          ],
+          "title": "SSO POST binding"
+        },
+        "single_logout_service_url": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "URL Location where the <LogoutRequest> from the IdP will be sent (IdP-initiated logout).",
+          "examples": [
+            "https://example.com/logout"
+          ],
+          "title": "SP Logout URL"
+        },
+        "single_logout_service_redirect_response_url": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "URL Location where the REDIRECT <LogoutResponse> from the IdP will sent (SP-initiated logout, reply): only specify if different from url parameter.",
+          "examples": [
+            "https://example.com/logout"
+          ],
+          "title": "SSO logout REDIRECT response URL"
+        },
+        "single_logout_service_redirect_binding": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "SAML protocol binding to be used when returning the REDIRECT <Response> message.",
+          "examples": [
+            "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+          ],
+          "title": "SSO logout REDIRECT binding"
+        },
+        "single_logout_service_post_response_url": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "URL Location where the POST <LogoutResponse> from the IdP will sent (SP-initiated logout, reply): only specify if different from url parameter.",
+          "examples": [
+            "https://example.com/logout"
+          ],
+          "title": "SSO logout POST response URL"
+        },
+        "single_logout_service_post_binding": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "SAML protocol binding to be used when returning the POST <Response> message.",
+          "examples": [
+            "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Post"
+          ],
+          "title": "SSO logout POST binding"
+        },
+        "x509certs": {
+          "description": "Comma separated list of public X.509 certificates of the IdP.",
+          "examples": [
+            "-----BEGIN CERTIFICATE-----\n            MIIC6DCCAdCgAwIBAgIUW42TU9LSjEZLMCclWrvSwAsgRtcwDQYJKoZIhvcNAQEL\n            BQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIzMDMyNDE4\n            NDMxOVoXDTI0MDMyMzE4NDMxOVowPDELMAkGA1UEAwwCb2sxLTArBgNVBC0MJGUw\n            NjVmMWI3LTE2OWEtNDE5YS1iNmQyLTc3OWJkOGM4NzIwNjCCASIwDQYJKoZIhvcN\n            AQEBBQADggEPADCCAQoCggEBAK42ixoklDH5K5i1NxXo/AFACDa956pE5RA57wlC\n            BfgUYaIDRmv7TUVJh6zoMZSD6wjSZl3QgP7UTTZeHbvs3QE9HUwEkH1Lo3a8vD3z\n            eqsE2vSnOkpWWnPbfxiQyrTm77/LAWBt7lRLRLdfL6WcucD3wsGqm58sWXM3HG0f\n            SN7PHCZUFqU6MpkHw8DiKmht5hBgWG+Vq3Zw8MNaqpwb/NgST3yYdcZwb58G2FTS\n            ZvDSdUfRmD/mY7TpciYV8EFylXNNFkth8oGNLunR9adgZ+9IunfRKj1a7S5GSwXU\n            AZDaojw+8k5i3ikztsWH11wAVCiLj/3euIqq95z8xGycnKcCAwEAATANBgkqhkiG\n            9w0BAQsFAAOCAQEAWMvcaozgBrZ/MAxzTJmp5gZyLxmMNV6iT9dcqbwzDtDtBvA/\n            46ux6ytAQ+A7Bd3AubvozwCr1Id6g66ae0blWYRRZmF8fDdX/SBjIUkv7u9A3NVQ\n            XN9gsEvK9pdpfN4ZiflfGSLdhM1STHycLmhG6H5s7HklbukMRhQi+ejbSzm/wiw1\n            ipcxuKhSUIVNkTLusN5b+HE2gwF1fn0K0z5jWABy08huLgbaEKXJEx5/FKLZGJga\n            fpIzAdf25kMTu3gggseaAmzyX3AtT1i8A8nqYfe8fnnVMkvud89kq5jErv/hlMC9\n            49g5yWQR2jilYYM3j9BHDuB+Rs+YS5BCep1JnQ==\n            -----END CERTIFICATE-----"
+          ],
+          "title": "Public IdP certificates",
+          "type": "string"
+        }
+      },
+      "required": [
+        "metadata",
+        "metadata_url",
+        "entity_id",
+        "single_sign_on_service_redirect_url",
+        "single_sign_on_service_redirect_binding",
+        "single_sign_on_service_post_url",
+        "single_sign_on_service_post_binding",
+        "single_logout_service_url",
+        "single_logout_service_redirect_response_url",
+        "single_logout_service_redirect_binding",
+        "single_logout_service_post_response_url",
+        "single_logout_service_post_binding",
+        "x509certs"
+      ],
+      "title": "SamlProviderData",
+      "type": "object"
+    }
+  },
+  "description": "Provider schema for SAML.",
+  "properties": {
+    "unit": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BaseModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "app": {
+      "$ref": "#/$defs/SamlProviderData"
+    }
+  },
+  "required": [
+    "app"
+  ],
+  "title": "ProviderSchema",
+  "type": "object"
+}

--- a/docs/json_schemas/saml/v1/requirer.json
+++ b/docs/json_schemas/saml/v1/requirer.json
@@ -1,0 +1,36 @@
+{
+  "$defs": {
+    "BaseModel": {
+      "properties": {},
+      "title": "BaseModel",
+      "type": "object"
+    }
+  },
+  "description": "Requirer schema for SAML.",
+  "properties": {
+    "unit": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BaseModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "app": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BaseModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    }
+  },
+  "title": "RequirerSchema",
+  "type": "object"
+}

--- a/interfaces/saml/v1/README.md
+++ b/interfaces/saml/v1/README.md
@@ -1,0 +1,97 @@
+# `saml`
+
+## Overview
+
+This relation interface describes the expected behavior between of any charm claiming to be able to interface with a SAML Provider and the SAML Provider itself. This interface has been defined to support charms that require Launchpad group information. Other Identity Providers can be used interchangeably as long as custom attributes are not required.
+
+## Usage
+
+In most cases, this will be accomplished using the [saml library](https://github.com/canonical/saml-integrator-operator/blob/main/lib/charms/saml_integrator/v1/saml.py), although charm developers are free to provide alternative libraries as long as they fulfil the behavioural and schematic requirements described in this document.
+
+## Direction
+
+The `saml` interface implements a provider/requirer pattern.
+The requirer is a charm that wishes to act as a SAML Service Provider, and the provider is a charm exposing a SAML Identity Provider.
+
+```mermaid
+flowchart TD
+    Provider -- metadata_url, metadata, entity_id, single_sign_on_service_redirect_url, single_sign_on_service_redirect_binding, x509certs --> Requirer
+```
+
+## Behavior
+
+The requirer and the provider must adhere to a certain set of criteria to be considered compatible with the interface.
+
+### Provider
+
+- Might provide the metadata_url in the relation databag.
+- Is expected to provide the metadata in the relation databag.
+- Is expected to provide the entity_id in the relation databag.
+- Is expected to provide the single_sign_on_service_redirect_url in the relation databag.
+- Is expected to provide the single_sign_on_service_redirect_binding in the relation databag.
+- Is expected to provide the x509certs in the relation databag.
+
+### Requirer
+
+- Is not expected to provide anything
+
+## Relation Data
+
+### Provider
+
+[\[JSON Schema\]](./schemas/provider.json)
+
+Provider provides the SAML configuration. It should be placed in the **application** databag.
+
+#### Example
+
+```yaml
+related-units: {}
+application_data: {
+  "metadata_url": "https://login.ubuntu.com/saml/metadata",
+  "metadata":"""<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://login.ubuntu.com">
+        <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <md:KeyDescriptor use="signing">
+            <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                <ds:X509Data>
+                    <ds:X509Certificate>MIICjzCCAfigAwIBAgIJALNN/vxaR1hyMA0GCSqGSIb3DQEBBQUAMDoxCzAJBgNVBAYTAkdCMRMwEQYDVQQIEwpTb21lLVN0YXRlMRYwFAYDVQQKEw1DYW5vbmljYWwgTHRkMB4XDTEyMDgxMDEyNDE0OFoXDTEzMDgxMDEyNDE0OFowOjELMAkGA1UEBhMCR0IxEzARBgNVBAgTClNvbWUtU3RhdGUxFjAUBgNVBAoTDUNhbm9uaWNhbCBMdGQwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMM4pmIxkv419q8zj5EojK57y6plU/+k3apX6w1PgAYeI0zhNuud/tiqKVQEDyZ6W7HNeGtWSh5rewy8c07BShcHG5Y8ibzBdIibGs5k6gvtmsRiXDE/F39+RrPSW18beHhEuoVJM9RANp3MYMOK11SiClSiGo+NfBKFuoqNX3UjAgMBAAGjgZwwgZkwHQYDVR0OBBYEFH/no88pbywRnW6Fz+B4lQ04w/86MGoGA1UdIwRjMGGAFH/no88pbywRnW6Fz+B4lQ04w/86oT6kPDA6MQswCQYDVQQGEwJHQjETMBEGA1UECBMKU29tZS1TdGF0ZTEWMBQGA1UEChMNQ2Fub25pY2FsIEx0ZIIJALNN/vxaR1hyMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEArTGbZ1rg++aBxnNuJ7eho62JKKtRW5O+kMBvBLWi7fKck5uXDE6d7Jv6hUy/gwUZV7r5kuPwRlw3Pu6AX4R60UsQuVG1/VVVI7nu32iCkXx5Vzq446IkVRdk/QOda1dRyq0oaifUUhJfwVFSsm95ENDFdGqD0raj7g77ajcBMf8=</ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </md:KeyDescriptor>
+        <md:KeyDescriptor use="encryption">
+            <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                <ds:X509Data>
+                    <ds:X509Certificate>MIICjzCCAfigAwIBAgIJALNN/vxaR1hyMA0GCSqGSIb3DQEBBQUAMDoxCzAJBgNVBAYTAkdCMRMwEQYDVQQIEwpTb21lLVN0YXRlMRYwFAYDVQQKEw1DYW5vbmljYWwgTHRkMB4XDTEyMDgxMDEyNDE0OFoXDTEzMDgxMDEyNDE0OFowOjELMAkGA1UEBhMCR0IxEzARBgNVBAgTClNvbWUtU3RhdGUxFjAUBgNVBAoTDUNhbm9uaWNhbCBMdGQwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMM4pmIxkv419q8zj5EojK57y6plU/+k3apX6w1PgAYeI0zhNuud/tiqKVQEDyZ6W7HNeGtWSh5rewy8c07BShcHG5Y8ibzBdIibGs5k6gvtmsRiXDE/F39+RrPSW18beHhEuoVJM9RANp3MYMOK11SiClSiGo+NfBKFuoqNX3UjAgMBAAGjgZwwgZkwHQYDVR0OBBYEFH/no88pbywRnW6Fz+B4lQ04w/86MGoGA1UdIwRjMGGAFH/no88pbywRnW6Fz+B4lQ04w/86oT6kPDA6MQswCQYDVQQGEwJHQjETMBEGA1UECBMKU29tZS1TdGF0ZTEWMBQGA1UEChMNQ2Fub25pY2FsIEx0ZIIJALNN/vxaR1hyMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEArTGbZ1rg++aBxnNuJ7eho62JKKtRW5O+kMBvBLWi7fKck5uXDE6d7Jv6hUy/gwUZV7r5kuPwRlw3Pu6AX4R60UsQuVG1/VVVI7nu32iCkXx5Vzq446IkVRdk/QOda1dRyq0oaifUUhJfwVFSsm95ENDFdGqD0raj7g77ajcBMf8=</ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </md:KeyDescriptor>
+        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login.ubuntu.com/+logout"/>
+        <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:email</md:NameIDFormat>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login.ubuntu.com/saml/"/>
+        </md:IDPSSODescriptor>
+    </md:EntityDescriptor>""",
+  "entity_id": "https://login.ubuntu.com",
+  "single_sign_on_service_redirect_url": "https://login.ubuntu.com/saml/",
+  "single_sign_on_service_redirect_binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+  "single_logout_service_redirect_url": "https://login.ubuntu.com/+logout",
+  "single_logout_service_redirect_binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+  "x509certs": """-----BEGIN CERTIFICATE-----
+      MIIC6DCCAdCgAwIBAgIUW42TU9LSjEZLMCclWrvSwAsgRtcwDQYJKoZIhvcNAQEL
+      BQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIzMDMyNDE4
+      NDMxOVoXDTI0MDMyMzE4NDMxOVowPDELMAkGA1UEAwwCb2sxLTArBgNVBC0MJGUw
+      NjVmMWI3LTE2OWEtNDE5YS1iNmQyLTc3OWJkOGM4NzIwNjCCASIwDQYJKoZIhvcN
+      AQEBBQADggEPADCCAQoCggEBAK42ixoklDH5K5i1NxXo/AFACDa956pE5RA57wlC
+      BfgUYaIDRmv7TUVJh6zoMZSD6wjSZl3QgP7UTTZeHbvs3QE9HUwEkH1Lo3a8vD3z
+      eqsE2vSnOkpWWnPbfxiQyrTm77/LAWBt7lRLRLdfL6WcucD3wsGqm58sWXM3HG0f
+      SN7PHCZUFqU6MpkHw8DiKmht5hBgWG+Vq3Zw8MNaqpwb/NgST3yYdcZwb58G2FTS
+      ZvDSdUfRmD/mY7TpciYV8EFylXNNFkth8oGNLunR9adgZ+9IunfRKj1a7S5GSwXU
+      AZDaojw+8k5i3ikztsWH11wAVCiLj/3euIqq95z8xGycnKcCAwEAATANBgkqhkiG
+      9w0BAQsFAAOCAQEAWMvcaozgBrZ/MAxzTJmp5gZyLxmMNV6iT9dcqbwzDtDtBvA/
+      46ux6ytAQ+A7Bd3AubvozwCr1Id6g66ae0blWYRRZmF8fDdX/SBjIUkv7u9A3NVQ
+      XN9gsEvK9pdpfN4ZiflfGSLdhM1STHycLmhG6H5s7HklbukMRhQi+ejbSzm/wiw1
+      ipcxuKhSUIVNkTLusN5b+HE2gwF1fn0K0z5jWABy08huLgbaEKXJEx5/FKLZGJga
+      fpIzAdf25kMTu3gggseaAmzyX3AtT1i8A8nqYfe8fnnVMkvud89kq5jErv/hlMC9
+      49g5yWQR2jilYYM3j9BHDuB+Rs+YS5BCep1JnQ==
+      -----END CERTIFICATE-----"""
+}
+```

--- a/interfaces/saml/v1/interface.yaml
+++ b/interfaces/saml/v1/interface.yaml
@@ -1,0 +1,11 @@
+name: saml
+
+version: 0
+status: published
+
+providers:
+  - name: saml-integrator
+    url: https://github.com/canonical/saml-integrator-operator
+
+requirers:
+  []

--- a/interfaces/saml/v1/interface_tests/test_provider.py
+++ b/interfaces/saml/v1/interface_tests/test_provider.py
@@ -1,0 +1,15 @@
+# Copyright 2023 Canonical
+# See LICENSE file for licensing details.
+from interface_tester.interface_test import Tester
+from scenario import Relation, State
+
+
+def test_data_published_on_created():
+    t = Tester(State(
+        relations=[Relation(
+            endpoint="saml",
+            interface="saml",
+        )],
+    ))
+    t.run("saml-relation-created")
+    t.assert_schema_valid()

--- a/interfaces/saml/v1/schema.py
+++ b/interfaces/saml/v1/schema.py
@@ -1,0 +1,178 @@
+# Copyright 2023 Canonical
+# See LICENSE file for licensing details.
+"""This file defines the schema for the provider side of the saml interface.
+
+It exposes one interfaces.schema_base.DataBagSchema subclass called:
+- ProviderSchema
+
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {"saml":
+                 {
+                    "metadata_url": "https://login.ubuntu.com/saml/metadata",
+                    "metadata": "
+                        <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://login.ubuntu.com">
+                            <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+                            <md:KeyDescriptor use="signing">
+                                <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                                    <ds:X509Data>
+                                        <ds:X509Certificate>MIICjzCCAfigAwIBAgIJALNN/vxaR1hyMA0GCSqGSIb3DQEBBQUAMDoxCzAJBgNVBAYTAkdCMRMwEQYDVQQIEwpTb21lLVN0YXRlMRYwFAYDVQQKEw1DYW5vbmljYWwgTHRkMB4XDTEyMDgxMDEyNDE0OFoXDTEzMDgxMDEyNDE0OFowOjELMAkGA1UEBhMCR0IxEzARBgNVBAgTClNvbWUtU3RhdGUxFjAUBgNVBAoTDUNhbm9uaWNhbCBMdGQwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMM4pmIxkv419q8zj5EojK57y6plU/+k3apX6w1PgAYeI0zhNuud/tiqKVQEDyZ6W7HNeGtWSh5rewy8c07BShcHG5Y8ibzBdIibGs5k6gvtmsRiXDE/F39+RrPSW18beHhEuoVJM9RANp3MYMOK11SiClSiGo+NfBKFuoqNX3UjAgMBAAGjgZwwgZkwHQYDVR0OBBYEFH/no88pbywRnW6Fz+B4lQ04w/86MGoGA1UdIwRjMGGAFH/no88pbywRnW6Fz+B4lQ04w/86oT6kPDA6MQswCQYDVQQGEwJHQjETMBEGA1UECBMKU29tZS1TdGF0ZTEWMBQGA1UEChMNQ2Fub25pY2FsIEx0ZIIJALNN/vxaR1hyMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEArTGbZ1rg++aBxnNuJ7eho62JKKtRW5O+kMBvBLWi7fKck5uXDE6d7Jv6hUy/gwUZV7r5kuPwRlw3Pu6AX4R60UsQuVG1/VVVI7nu32iCkXx5Vzq446IkVRdk/QOda1dRyq0oaifUUhJfwVFSsm95ENDFdGqD0raj7g77ajcBMf8=</ds:X509Certificate>
+                                    </ds:X509Data>
+                                </ds:KeyInfo>
+                            </md:KeyDescriptor>
+                            <md:KeyDescriptor use="encryption">
+                                <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                                    <ds:X509Data>
+                                        <ds:X509Certificate>MIICjzCCAfigAwIBAgIJALNN/vxaR1hyMA0GCSqGSIb3DQEBBQUAMDoxCzAJBgNVBAYTAkdCMRMwEQYDVQQIEwpTb21lLVN0YXRlMRYwFAYDVQQKEw1DYW5vbmljYWwgTHRkMB4XDTEyMDgxMDEyNDE0OFoXDTEzMDgxMDEyNDE0OFowOjELMAkGA1UEBhMCR0IxEzARBgNVBAgTClNvbWUtU3RhdGUxFjAUBgNVBAoTDUNhbm9uaWNhbCBMdGQwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMM4pmIxkv419q8zj5EojK57y6plU/+k3apX6w1PgAYeI0zhNuud/tiqKVQEDyZ6W7HNeGtWSh5rewy8c07BShcHG5Y8ibzBdIibGs5k6gvtmsRiXDE/F39+RrPSW18beHhEuoVJM9RANp3MYMOK11SiClSiGo+NfBKFuoqNX3UjAgMBAAGjgZwwgZkwHQYDVR0OBBYEFH/no88pbywRnW6Fz+B4lQ04w/86MGoGA1UdIwRjMGGAFH/no88pbywRnW6Fz+B4lQ04w/86oT6kPDA6MQswCQYDVQQGEwJHQjETMBEGA1UECBMKU29tZS1TdGF0ZTEWMBQGA1UEChMNQ2Fub25pY2FsIEx0ZIIJALNN/vxaR1hyMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEArTGbZ1rg++aBxnNuJ7eho62JKKtRW5O+kMBvBLWi7fKck5uXDE6d7Jv6hUy/gwUZV7r5kuPwRlw3Pu6AX4R60UsQuVG1/VVVI7nu32iCkXx5Vzq446IkVRdk/QOda1dRyq0oaifUUhJfwVFSsm95ENDFdGqD0raj7g77ajcBMf8=</ds:X509Certificate>
+                                    </ds:X509Data>
+                                </ds:KeyInfo>
+                            </md:KeyDescriptor>
+                            <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login.ubuntu.com/+logout"/>
+                            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:email</md:NameIDFormat>
+                            <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login.ubuntu.com/saml/"/>
+                            </md:IDPSSODescriptor>
+                        </md:EntityDescriptor>
+                    ",
+                    "entity_id": "https://login.ubuntu.com",
+                    "single_sign_on_service_redirect_url": "https://login.ubuntu.com/saml/",
+                    "single_sign_on_service_redirect_binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                    "single_logout_service_redirect_url": "https://login.ubuntu.com/+logout",
+                    "single_logout_service_redirect_binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                    "x509certs": "-----BEGIN CERTIFICATE-----\n
+                        MIIC6DCCAdCgAwIBAgIUW42TU9LSjEZLMCclWrvSwAsgRtcwDQYJKoZIhvcNAQEL\n
+                        BQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIzMDMyNDE4\n
+                        NDMxOVoXDTI0MDMyMzE4NDMxOVowPDELMAkGA1UEAwwCb2sxLTArBgNVBC0MJGUw\n
+                        NjVmMWI3LTE2OWEtNDE5YS1iNmQyLTc3OWJkOGM4NzIwNjCCASIwDQYJKoZIhvcN\n
+                        AQEBBQADggEPADCCAQoCggEBAK42ixoklDH5K5i1NxXo/AFACDa956pE5RA57wlC\n
+                        BfgUYaIDRmv7TUVJh6zoMZSD6wjSZl3QgP7UTTZeHbvs3QE9HUwEkH1Lo3a8vD3z\n
+                        eqsE2vSnOkpWWnPbfxiQyrTm77/LAWBt7lRLRLdfL6WcucD3wsGqm58sWXM3HG0f\n
+                        SN7PHCZUFqU6MpkHw8DiKmht5hBgWG+Vq3Zw8MNaqpwb/NgST3yYdcZwb58G2FTS\n
+                        ZvDSdUfRmD/mY7TpciYV8EFylXNNFkth8oGNLunR9adgZ+9IunfRKj1a7S5GSwXU\n
+                        AZDaojw+8k5i3ikztsWH11wAVCiLj/3euIqq95z8xGycnKcCAwEAATANBgkqhkiG\n
+                        9w0BAQsFAAOCAQEAWMvcaozgBrZ/MAxzTJmp5gZyLxmMNV6iT9dcqbwzDtDtBvA/\n
+                        46ux6ytAQ+A7Bd3AubvozwCr1Id6g66ae0blWYRRZmF8fDdX/SBjIUkv7u9A3NVQ\n
+                        XN9gsEvK9pdpfN4ZiflfGSLdhM1STHycLmhG6H5s7HklbukMRhQi+ejbSzm/wiw1\n
+                        ipcxuKhSUIVNkTLusN5b+HE2gwF1fn0K0z5jWABy08huLgbaEKXJEx5/FKLZGJga\n
+                        fpIzAdf25kMTu3gggseaAmzyX3AtT1i8A8nqYfe8fnnVMkvud89kq5jErv/hlMC9\n
+                        49g5yWQR2jilYYM3j9BHDuB+Rs+YS5BCep1JnQ==\n
+                        -----END CERTIFICATE-----\n"
+                }
+             }
+"""
+from interface_tester.schema_base import DataBagSchema
+from pydantic import AnyHttpUrl, BaseModel, Field
+from typing import Optional
+
+
+class SamlProviderData(BaseModel):
+    metadata: str = Field(
+        description="IdP's metadata.",
+        title="Metadata",
+        examples=["""<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://login.ubuntu.com">
+            <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+            <md:KeyDescriptor use="signing">
+                <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                    <ds:X509Data>
+                        <ds:X509Certificate>MIICjzCCAfigAwIBAgIJALNN/vxaR1hyMA0GCSqGSIb3DQEBBQUAMDoxCzAJBgNVBAYTAkdCMRMwEQYDVQQIEwpTb21lLVN0YXRlMRYwFAYDVQQKEw1DYW5vbmljYWwgTHRkMB4XDTEyMDgxMDEyNDE0OFoXDTEzMDgxMDEyNDE0OFowOjELMAkGA1UEBhMCR0IxEzARBgNVBAgTClNvbWUtU3RhdGUxFjAUBgNVBAoTDUNhbm9uaWNhbCBMdGQwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMM4pmIxkv419q8zj5EojK57y6plU/+k3apX6w1PgAYeI0zhNuud/tiqKVQEDyZ6W7HNeGtWSh5rewy8c07BShcHG5Y8ibzBdIibGs5k6gvtmsRiXDE/F39+RrPSW18beHhEuoVJM9RANp3MYMOK11SiClSiGo+NfBKFuoqNX3UjAgMBAAGjgZwwgZkwHQYDVR0OBBYEFH/no88pbywRnW6Fz+B4lQ04w/86MGoGA1UdIwRjMGGAFH/no88pbywRnW6Fz+B4lQ04w/86oT6kPDA6MQswCQYDVQQGEwJHQjETMBEGA1UECBMKU29tZS1TdGF0ZTEWMBQGA1UEChMNQ2Fub25pY2FsIEx0ZIIJALNN/vxaR1hyMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEArTGbZ1rg++aBxnNuJ7eho62JKKtRW5O+kMBvBLWi7fKck5uXDE6d7Jv6hUy/gwUZV7r5kuPwRlw3Pu6AX4R60UsQuVG1/VVVI7nu32iCkXx5Vzq446IkVRdk/QOda1dRyq0oaifUUhJfwVFSsm95ENDFdGqD0raj7g77ajcBMf8=</ds:X509Certificate>
+                    </ds:X509Data>
+                </ds:KeyInfo>
+            </md:KeyDescriptor>
+            <md:KeyDescriptor use="encryption">
+                <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                    <ds:X509Data>
+                        <ds:X509Certificate>MIICjzCCAfigAwIBAgIJALNN/vxaR1hyMA0GCSqGSIb3DQEBBQUAMDoxCzAJBgNVBAYTAkdCMRMwEQYDVQQIEwpTb21lLVN0YXRlMRYwFAYDVQQKEw1DYW5vbmljYWwgTHRkMB4XDTEyMDgxMDEyNDE0OFoXDTEzMDgxMDEyNDE0OFowOjELMAkGA1UEBhMCR0IxEzARBgNVBAgTClNvbWUtU3RhdGUxFjAUBgNVBAoTDUNhbm9uaWNhbCBMdGQwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMM4pmIxkv419q8zj5EojK57y6plU/+k3apX6w1PgAYeI0zhNuud/tiqKVQEDyZ6W7HNeGtWSh5rewy8c07BShcHG5Y8ibzBdIibGs5k6gvtmsRiXDE/F39+RrPSW18beHhEuoVJM9RANp3MYMOK11SiClSiGo+NfBKFuoqNX3UjAgMBAAGjgZwwgZkwHQYDVR0OBBYEFH/no88pbywRnW6Fz+B4lQ04w/86MGoGA1UdIwRjMGGAFH/no88pbywRnW6Fz+B4lQ04w/86oT6kPDA6MQswCQYDVQQGEwJHQjETMBEGA1UECBMKU29tZS1TdGF0ZTEWMBQGA1UEChMNQ2Fub25pY2FsIEx0ZIIJALNN/vxaR1hyMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEArTGbZ1rg++aBxnNuJ7eho62JKKtRW5O+kMBvBLWi7fKck5uXDE6d7Jv6hUy/gwUZV7r5kuPwRlw3Pu6AX4R60UsQuVG1/VVVI7nu32iCkXx5Vzq446IkVRdk/QOda1dRyq0oaifUUhJfwVFSsm95ENDFdGqD0raj7g77ajcBMf8=</ds:X509Certificate>
+                    </ds:X509Data>
+                </ds:KeyInfo>
+            </md:KeyDescriptor>
+            <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login.ubuntu.com/+logout"/>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:email</md:NameIDFormat>
+            <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login.ubuntu.com/saml/"/>
+            </md:IDPSSODescriptor>
+        </md:EntityDescriptor>"""],
+    )
+    metadata_url: Optional[AnyHttpUrl] = Field(
+        description="URL to the IdP's metadata.",
+        title="Metadata URL",
+        examples=["https://login.ubuntu.com/saml/metadata"],
+    )
+    entity_id: AnyHttpUrl = Field(
+        description="Identifier of the IdP entity.",
+        title="Entity ID",
+        examples=["https://login.ubuntu.com"],
+    )
+    single_sign_on_service_redirect_url: AnyHttpUrl = Field(
+        description="URL target of the IdP where the Authentication REDIRECT Request Message will be sent.",
+        title="SSO REDIRECT URL",
+        examples=["https://login.ubuntu.com/saml/"],
+    )
+    single_sign_on_service_redirect_binding: str = Field(
+        description="SAML protocol binding to be used when returning the REDIRECT <Response> message.",
+        title="SSO REDIRECT binding",
+        examples=["urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"],
+    )
+    single_sign_on_service_post_url: Optional[AnyHttpUrl] = Field(
+        description="URL target of the IdP where the Authentication POST Request Message will be sent.",
+        title="SSO POST response URL",
+        examples=["https://login.ubuntu.com/saml/"],
+    )
+    single_sign_on_service_post_binding: Optional[str] = Field(
+        description="SAML protocol binding to be used when returning the POST <Response> message.",
+        title="SSO POST binding",
+        examples=["urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Post"],
+    )
+    single_logout_service_url: Optional[AnyHttpUrl] = Field(
+        description="URL Location where the <LogoutRequest> from the IdP will be sent (IdP-initiated logout).",
+        title="SP Logout URL",
+        examples=["https://example.com/logout"],
+    )
+    single_logout_service_redirect_response_url: Optional[AnyHttpUrl] = Field(
+        description="URL Location where the REDIRECT <LogoutResponse> from the IdP will sent (SP-initiated logout, reply): only specify if different from url parameter.",
+        title="SSO logout REDIRECT response URL",
+        examples=["https://example.com/logout"],
+    )
+    single_logout_service_redirect_binding: Optional[str] = Field(
+        description="SAML protocol binding to be used when returning the REDIRECT <Response> message.",
+        title="SSO logout REDIRECT binding",
+        examples=["urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"],
+    )
+    single_logout_service_post_response_url: Optional[AnyHttpUrl] = Field(
+        description="URL Location where the POST <LogoutResponse> from the IdP will sent (SP-initiated logout, reply): only specify if different from url parameter.",
+        title="SSO logout POST response URL",
+        examples=["https://example.com/logout"],
+    )
+    single_logout_service_post_binding: Optional[str] = Field(
+        description="SAML protocol binding to be used when returning the POST <Response> message.",
+        title="SSO logout POST binding",
+        examples=["urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Post"],
+    )
+    x509certs: str = Field(
+        description="Comma separated list of public X.509 certificates of the IdP.",
+        title="Public IdP certificates",
+        examples=["""-----BEGIN CERTIFICATE-----
+            MIIC6DCCAdCgAwIBAgIUW42TU9LSjEZLMCclWrvSwAsgRtcwDQYJKoZIhvcNAQEL
+            BQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIzMDMyNDE4
+            NDMxOVoXDTI0MDMyMzE4NDMxOVowPDELMAkGA1UEAwwCb2sxLTArBgNVBC0MJGUw
+            NjVmMWI3LTE2OWEtNDE5YS1iNmQyLTc3OWJkOGM4NzIwNjCCASIwDQYJKoZIhvcN
+            AQEBBQADggEPADCCAQoCggEBAK42ixoklDH5K5i1NxXo/AFACDa956pE5RA57wlC
+            BfgUYaIDRmv7TUVJh6zoMZSD6wjSZl3QgP7UTTZeHbvs3QE9HUwEkH1Lo3a8vD3z
+            eqsE2vSnOkpWWnPbfxiQyrTm77/LAWBt7lRLRLdfL6WcucD3wsGqm58sWXM3HG0f
+            SN7PHCZUFqU6MpkHw8DiKmht5hBgWG+Vq3Zw8MNaqpwb/NgST3yYdcZwb58G2FTS
+            ZvDSdUfRmD/mY7TpciYV8EFylXNNFkth8oGNLunR9adgZ+9IunfRKj1a7S5GSwXU
+            AZDaojw+8k5i3ikztsWH11wAVCiLj/3euIqq95z8xGycnKcCAwEAATANBgkqhkiG
+            9w0BAQsFAAOCAQEAWMvcaozgBrZ/MAxzTJmp5gZyLxmMNV6iT9dcqbwzDtDtBvA/
+            46ux6ytAQ+A7Bd3AubvozwCr1Id6g66ae0blWYRRZmF8fDdX/SBjIUkv7u9A3NVQ
+            XN9gsEvK9pdpfN4ZiflfGSLdhM1STHycLmhG6H5s7HklbukMRhQi+ejbSzm/wiw1
+            ipcxuKhSUIVNkTLusN5b+HE2gwF1fn0K0z5jWABy08huLgbaEKXJEx5/FKLZGJga
+            fpIzAdf25kMTu3gggseaAmzyX3AtT1i8A8nqYfe8fnnVMkvud89kq5jErv/hlMC9
+            49g5yWQR2jilYYM3j9BHDuB+Rs+YS5BCep1JnQ==
+            -----END CERTIFICATE-----"""],
+    )
+
+
+class ProviderSchema(DataBagSchema):
+    """Provider schema for SAML."""
+    app: SamlProviderData
+
+class RequirerSchema(DataBagSchema):
+    """Requirer schema for SAML."""


### PR DESCRIPTION
Some IDPs do not provide a public metadata URL, as reported in https://github.com/canonical/saml-integrator-operator/issues/89

This new version of the interface makes the `metadata_url` optional and adds a mandatory `metadata` key for the metadata content