### PR TITLE
fix: sdcore_config interface tests

### DIFF
--- a/interfaces/sdcore_config/v0/interface.yaml
+++ b/interfaces/sdcore_config/v0/interface.yaml
@@ -2,7 +2,7 @@ name: sdcore_config
 internal: true
 
 version: 0
-status: draft
+status: published
 
 providers:
   - name: sdcore-nms-k8s

--- a/interfaces/sdcore_config/v0/interface_tests/test_provider.py
+++ b/interfaces/sdcore_config/v0/interface_tests/test_provider.py
@@ -1,8 +1,15 @@
 # Copyright 2024 Canonical
 # See LICENSE file for licensing details.
 
-from interface_tester.interface_test import Tester
+from interface_tester import Tester
 from scenario import State, Relation
+import json
+
+
+def test_no_data_on_created():
+    t = Tester()
+    t.run("sdcore-config-relation-created")
+    t.assert_relation_data_empty()
 
 
 def test_data_published_on_created():
@@ -16,9 +23,8 @@ def test_data_published_on_created():
             ],
         )
     )
-    state_out: State = t.run("sdcore-config-relation-created")
-    t.assert_schema_valid()
-    assert state_out.unit_status.name == 'active'
+    t.run("sdcore-config-relation-created")
+    t.assert_relation_data_empty()
 
 
 def test_data_published_on_joined():
@@ -32,39 +38,5 @@ def test_data_published_on_joined():
             ],
         )
     )
-    state_out: State = t.run("sdcore-config-relation-joined")
+    t.run("sdcore-config-relation-joined")
     t.assert_schema_valid()
-    assert state_out.unit_status.name == 'active'
-
-
-def test_data_published_on_changed():
-    t = Tester(
-        State(
-            relations=[
-                Relation(
-                    endpoint="sdcore_config",
-                    interface="sdcore_config",
-                )
-            ],
-        )
-    )
-    state_out: State = t.run("sdcore-config-relation-changed")
-    t.assert_schema_valid()
-    assert state_out.unit_status.name == 'active'
-
-
-def test_no_data_on_broken():
-    t = Tester(
-        State(
-            relations=[
-                Relation(
-                    endpoint="sdcore_config",
-                    interface="sdcore_config",
-                )
-            ],
-        )
-    )
-    state_out: State = t.run("sdcore-config-relation-broken")
-    t.assert_relation_data_empty()
-    assert state_out.unit_status.name == 'active'
-

--- a/interfaces/sdcore_config/v0/interface_tests/test_requirer.py
+++ b/interfaces/sdcore_config/v0/interface_tests/test_requirer.py
@@ -5,33 +5,17 @@ from interface_tester import Tester
 from scenario import Relation, State
 
 
-def test_state_active_on_joined():
+def test_no_data_on_joined():
     t = Tester(
         State(
             relations=[
                 Relation(
                     endpoint="sdcore_config",
                     interface="sdcore_config",
+                    remote_app_data={"webui_url": "some_url:123"},
                 )
             ],
         )
     )
-    state_out: State = t.run('sdcore-config-relation-joined')
-    assert state_out.unit_status.name == 'active'
-
-
-def test_state_blocked_on_broken():
-    t = Tester(
-        State(
-            relations=[
-                Relation(
-                    endpoint="sdcore_config",
-                    interface="sdcore_config",
-                )
-            ],
-        )
-    )
-    state_out: State = t.run('sdcore-config-relation-broken')
-    assert state_out.unit_status.name == 'blocked'
-
-
+    t.run('sdcore-config-relation-joined')
+    t.assert_relation_data_empty()


### PR DESCRIPTION
`sdcore_config` interface tests are failing. This PR together with the following fixes it:

- https://github.com/canonical/sdcore-udm-k8s-operator/pull/277 
- https://github.com/canonical/sdcore-udr-k8s-operator/pull/293 
- https://github.com/canonical/sdcore-smf-k8s-operator/pull/318 
- https://github.com/canonical/sdcore-pcf-k8s-operator/pull/292 
- https://github.com/canonical/sdcore-nssf-k8s-operator/pull/280 
- https://github.com/canonical/sdcore-nrf-k8s-operator/pull/330 
- https://github.com/canonical/sdcore-ausf-k8s-operator/pull/286 
- https://github.com/canonical/sdcore-amf-k8s-operator/pull/377 
- https://github.com/canonical/sdcore-nms-k8s-operator/pull/302 