### PR TITLE
chore: fix failed unit, integration tests json schema check

### DIFF
--- a/docs/json_schemas/dns_record/v0/provider.json
+++ b/docs/json_schemas/dns_record/v0/provider.json
@@ -35,11 +35,7 @@
           "type": "string"
         },
         "status": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/Status"
-            }
-          ],
+          "$ref": "#/$defs/Status",
           "description": "Status for the domain request.",
           "examples": [
             "approved",

--- a/docs/json_schemas/dns_record/v0/requirer.json
+++ b/docs/json_schemas/dns_record/v0/requirer.json
@@ -101,11 +101,7 @@
           "type": "integer"
         },
         "record_class": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/RecordClass"
-            }
-          ],
+          "$ref": "#/$defs/RecordClass",
           "default": null,
           "description": "The DNS record class.",
           "examples": [
@@ -114,11 +110,7 @@
           "name": "Record class"
         },
         "record_type": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/RecordType"
-            }
-          ],
+          "$ref": "#/$defs/RecordType",
           "default": null,
           "description": "The DNS record type.",
           "examples": [

--- a/docs/json_schemas/kratos_external_idp/v0/provider.json
+++ b/docs/json_schemas/kratos_external_idp/v0/provider.json
@@ -16,11 +16,7 @@
           "type": "string"
         },
         "secret_backend": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/SecretBackend"
-            }
-          ],
+          "$ref": "#/$defs/SecretBackend",
           "default": "relation"
         },
         "provider": {

--- a/docs/json_schemas/smtp/v0/provider.json
+++ b/docs/json_schemas/smtp/v0/provider.json
@@ -84,11 +84,7 @@
           "title": "Password ID"
         },
         "auth_type": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/AuthType"
-            }
-          ],
+          "$ref": "#/$defs/AuthType",
           "description": "The type used to authenticate with the SMTP relay.",
           "examples": [
             "none"
@@ -96,11 +92,7 @@
           "title": "Auth type"
         },
         "transport_security": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/TransportSecurity"
-            }
-          ],
+          "$ref": "#/$defs/TransportSecurity",
           "description": "The security protocol to use for the SMTP relay.",
           "examples": [
             "none"

--- a/docs/json_schemas/tracing/v2/provider.json
+++ b/docs/json_schemas/tracing/v2/provider.json
@@ -20,11 +20,7 @@
           "type": "string"
         },
         "type": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/TransportProtocolType"
-            }
-          ],
+          "$ref": "#/$defs/TransportProtocolType",
           "description": "The transport protocol used by this receiver.",
           "examples": [
             "http",
@@ -43,11 +39,7 @@
       "description": "Specification of an active receiver.",
       "properties": {
         "protocol": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/ProtocolType"
-            }
-          ],
+          "$ref": "#/$defs/ProtocolType",
           "description": "Receiver protocol name and type."
         },
         "url": {

--- a/interfaces/__template__/v0/interface_tests/README.md
+++ b/interfaces/__template__/v0/interface_tests/README.md
@@ -11,7 +11,6 @@ Copy this test to `test_provider.py` and fill in the blanks however appropriate 
 ```python
 from interface_tester import Tester
 import scenario
-import scenario.context
 
 def test_data_published_on_changed_remote_valid():
     # GIVEN a relation over <interface> containing all the right data 

--- a/interfaces/__template__/v0/interface_tests/README.md
+++ b/interfaces/__template__/v0/interface_tests/README.md
@@ -9,23 +9,24 @@ Find some relevant documentation at:
 Copy this test to `test_provider.py` and fill in the blanks however appropriate for your interfaces
 
 ```python
-from scenario import Relation, State
 from interface_tester import Tester
+import scenario
+import scenario.context
 
 def test_data_published_on_changed_remote_valid():
     # GIVEN a relation over <interface> containing all the right data 
     #  in the right format for the <requirer side>:
-    relation = Relation(
+    relation = scenario.Relation(
         endpoint='ingress',
         interface='ingress', remote_app_name='remote',
         remote_app_data={'foo': '"bar"', 'baz': '42', 'qux': '"www.lol.com:4242"', },
         remote_units_data={0: {'fizz': 'buzz', }})
     t = Tester(
-        State(relations=[relation])
+        scenario.State(relations=[relation])
     )
     
     # WHEN the <provider side> receives a <endpoint-changed-event> event:
-    t.run(relation.changed_event)
+    t.run(scenario.context.CharmEvents.relation_changed(relation))
     
     # THEN the <provider side> also publishes valid data to its side of the relation 
     #  (if applicable)

--- a/interfaces/cos_agent/v0/interface_tests/test_provider.py
+++ b/interfaces/cos_agent/v0/interface_tests/test_provider.py
@@ -3,8 +3,7 @@
 
 import json
 from interface_tester import Tester
-from scenario import State, Relation
-
+import scenario.context
 
 def test_no_data_on_created():
     t = Tester()
@@ -84,11 +83,11 @@ valid_unit_data = {
 valid_unit_data["config"] = json.dumps(valid_unit_data["config"])
 
 def test_on_changed_with_existing_valid_data():
-    relation = Relation(
+    relation = scenario.Relation(
         endpoint="cos-agent",
         interface="cos-agent",
         local_unit_data=valid_unit_data,
     )
-    t = Tester(State(relations=[relation]))
-    state_out = t.run(relation.changed_event)
+    t = Tester(scenario.State(relations=[relation]))
+    state_out = t.run(scenario.context.CharmEvents.relation_changed(relation))
     t.assert_schema_valid()

--- a/interfaces/cos_agent/v0/interface_tests/test_provider.py
+++ b/interfaces/cos_agent/v0/interface_tests/test_provider.py
@@ -2,8 +2,10 @@
 # See LICENSE file for licensing details.
 
 import json
+
+import scenario
 from interface_tester import Tester
-import scenario.context
+
 
 def test_no_data_on_created():
     t = Tester()
@@ -16,10 +18,12 @@ def test_no_data_on_joined():
     state_out = t.run("cos-agent-relation-joined")
     t.assert_schema_valid()
 
+
 def test_no_data_on_changed():
     t = Tester()
     state_out = t.run("cos-agent-relation-changed")
     t.assert_schema_valid()
+
 
 valid_unit_data = {
     "config": {
@@ -81,6 +85,7 @@ valid_unit_data = {
 }
 
 valid_unit_data["config"] = json.dumps(valid_unit_data["config"])
+
 
 def test_on_changed_with_existing_valid_data():
     relation = scenario.Relation(

--- a/interfaces/ingress/v1/interface_tests/test_provider.py
+++ b/interfaces/ingress/v1/interface_tests/test_provider.py
@@ -1,18 +1,19 @@
 # Copyright 2024 Canonical
 # See LICENSE file for licensing details.
-from interface_tester import Tester
 import scenario
-import scenario.context
+from interface_tester import Tester
+
 
 def test_no_data_on_created():
     t = Tester(
-        scenario.State(leader=True,
+        scenario.State(
+            leader=True,
             relations=[
                 scenario.Relation(
                     endpoint="ingress",
                     interface="ingress",
                 )
-            ]
+            ],
         )
     )
     state_out = t.run("ingress-relation-created")
@@ -22,13 +23,14 @@ def test_no_data_on_created():
 def test_no_data_on_joined():
     # nothing happens on joined: databags are empty
     t = Tester(
-        scenario.State(leader=True,
+        scenario.State(
+            leader=True,
             relations=[
                 scenario.Relation(
                     endpoint="ingress",
                     interface="ingress",
                 )
-            ]
+            ],
         )
     )
     state_out = t.run("ingress-relation-joined")
@@ -37,8 +39,14 @@ def test_no_data_on_joined():
 
 def test_data_published_on_changed_remote_valid():
     ingress = scenario.Relation(
-        endpoint='ingress', interface='ingress',
-        remote_app_data={'host': '"0.0.0.42"', 'model': '"bar"', 'name': '"remote/0"', 'port': '42'}
+        endpoint="ingress",
+        interface="ingress",
+        remote_app_data={
+            "host": '"0.0.0.42"',
+            "model": '"bar"',
+            "name": '"remote/0"',
+            "port": "42",
+        },
     )
     t = Tester(scenario.State(leader=True, relations=[ingress]))
     state_out = t.run(scenario.context.CharmEvents.relation_changed(ingress))
@@ -48,16 +56,19 @@ def test_data_published_on_changed_remote_valid():
 def test_no_data_published_on_changed_remote_invalid():
     # on changed, if the remote side has sent INvalid data: local side didn't publish anything either.
     t = Tester(
-        scenario.State(leader=True,
-            relations=[scenario.Relation(
-                endpoint='ingress',
-                interface='ingress',
-                remote_app_data={
-                    'host': '0.0.0.42',
-                    'bubble': "10",
-                    'rubble': "foo"
-                }
-            )]
+        scenario.State(
+            leader=True,
+            relations=[
+                scenario.Relation(
+                    endpoint="ingress",
+                    interface="ingress",
+                    remote_app_data={
+                        "host": "0.0.0.42",
+                        "bubble": "10",
+                        "rubble": "foo",
+                    },
+                )
+            ],
         )
     )
     state_out = t.run("ingress-relation-changed")

--- a/interfaces/ingress/v1/interface_tests/test_provider.py
+++ b/interfaces/ingress/v1/interface_tests/test_provider.py
@@ -1,16 +1,14 @@
-# Copyright 2023 Canonical
+# Copyright 2024 Canonical
 # See LICENSE file for licensing details.
-import yaml
-
 from interface_tester import Tester
-from scenario import State, Relation
-
+import scenario
+import scenario.context
 
 def test_no_data_on_created():
     t = Tester(
-        State(leader=True,
+        scenario.State(leader=True,
             relations=[
-                Relation(
+                scenario.Relation(
                     endpoint="ingress",
                     interface="ingress",
                 )
@@ -24,9 +22,9 @@ def test_no_data_on_created():
 def test_no_data_on_joined():
     # nothing happens on joined: databags are empty
     t = Tester(
-        State(leader=True,
+        scenario.State(leader=True,
             relations=[
-                Relation(
+                scenario.Relation(
                     endpoint="ingress",
                     interface="ingress",
                 )
@@ -38,29 +36,29 @@ def test_no_data_on_joined():
 
 
 def test_data_published_on_changed_remote_valid():
-    ingress = Relation(
+    ingress = scenario.Relation(
         endpoint='ingress', interface='ingress',
         remote_app_data={'host': '"0.0.0.42"', 'model': '"bar"', 'name': '"remote/0"', 'port': '42'}
     )
-    t = Tester(State(leader=True, relations=[ingress]))
-    state_out = t.run(ingress.changed_event)
+    t = Tester(scenario.State(leader=True, relations=[ingress]))
+    state_out = t.run(scenario.context.CharmEvents.relation_changed(ingress))
     t.assert_schema_valid()
 
 
 def test_no_data_published_on_changed_remote_invalid():
     # on changed, if the remote side has sent INvalid data: local side didn't publish anything either.
     t = Tester(
-        State(leader=True,
-              relations=[Relation(
-                  endpoint='ingress',
-                  interface='ingress',
-                  remote_app_data={
-                      'host': '0.0.0.42',
-                      'bubble': "10",
-                      'rubble': "foo"
-                  }
-              )]
-              )
+        scenario.State(leader=True,
+            relations=[scenario.Relation(
+                endpoint='ingress',
+                interface='ingress',
+                remote_app_data={
+                    'host': '0.0.0.42',
+                    'bubble': "10",
+                    'rubble': "foo"
+                }
+            )]
+        )
     )
     state_out = t.run("ingress-relation-changed")
     t.assert_relation_data_empty()

--- a/interfaces/ingress/v2/interface_tests/test_provider.py
+++ b/interfaces/ingress/v2/interface_tests/test_provider.py
@@ -1,21 +1,21 @@
-# Copyright 2023 Canonical
+# Copyright 2024 Canonical
 # See LICENSE file for licensing details.
 
 from interface_tester import Tester
-from scenario import State, Relation
-
+import scenario
+import scenario.context
 
 def test_no_data_on_created():
     # nothing happens on created: databags are empty
     t = Tester(
-        State(leader=True,
-              relations=[
-                  Relation(
-                      endpoint="ingress",
-                      interface="ingress",
-                  )
-              ]
-              )
+        scenario.State(leader=True,
+            relations=[
+                scenario.Relation(
+                    endpoint="ingress",
+                    interface="ingress",
+                )
+            ]
+        )
     )
     state_out = t.run("ingress-relation-created")
     t.assert_relation_data_empty()
@@ -24,55 +24,43 @@ def test_no_data_on_created():
 def test_no_data_on_joined():
     # nothing happens on joined: databags are empty
     t = Tester(
-        State(leader=True,
-              relations=[
-                  Relation(
-                      endpoint="ingress",
-                      interface="ingress",
-                  )
-              ]
-              )
+        scenario.State(leader=True,
+            relations=[
+                scenario.Relation(
+                    endpoint="ingress",
+                    interface="ingress",
+                )
+            ]
+        )
     )
     state_out = t.run("ingress-relation-joined")
     t.assert_relation_data_empty()
 
 
 def test_data_published_on_changed_remote_valid():
-    relation = Relation(endpoint='ingress', interface='ingress', remote_app_name='remote',
-                        remote_app_data={'model': '"bar"', 'port': '42', 'name': '"remote"', },
-                        remote_units_data={0: {'host': '"0.0.0.42"', }})
-    t = Tester(State(
-        relations=[relation]
-    )
-    )
-    state_out = t.run(relation.changed_event)
+    relation = scenario.Relation(endpoint='ingress', interface='ingress', remote_app_name='remote',
+                                 remote_app_data={'model': '"bar"', 'port': '42', 'name': '"remote"', },
+                                 remote_units_data={0: {'host': '"0.0.0.42"', }})
+    t = Tester(scenario.State(relations=[relation]))
+    state_out = t.run(scenario.context.CharmEvents.relation_changed(relation))
     t.assert_schema_valid()
 
 
 def test_data_published_on_changed_remote_invalid_json():
     # on changed, if the remote side has sent invalid json: local side didn't publish anything either.
-    ingress = Relation(endpoint='ingress', interface='ingress',
-                       remote_app_data={'model': 'bar', 'port': '42', 'name': 'true', },
-                       remote_units_data={0: {'host': '0.0.0.42', }})
-    t = Tester(
-        State(leader=True,
-              relations=[ingress]
-              )
-    )
-    state_out = t.run(ingress.changed_event)
+    ingress = scenario.Relation(endpoint='ingress', interface='ingress',
+                                remote_app_data={'model': 'bar', 'port': '42', 'name': 'true', },
+                                remote_units_data={0: {'host': '0.0.0.42', }})
+    t = Tester(scenario.State(leader=True, relations=[ingress]))
+    state_out = t.run(scenario.context.CharmEvents.relation_changed(ingress))
     t.assert_relation_data_empty()
 
 
 def test_data_published_on_changed_remote_invalid():
     # on changed, if the remote side has sent invalid data: local side didn't publish anything either.
-    ingress = Relation(endpoint='ingress', interface='ingress',
-                       remote_app_data={'model': '"bar"', 'port': '42', 'name': '"true"'},
-                       remote_units_data={0: {'bubble': 'blabla', }})
-    t = Tester(
-        State(leader=True,
-              relations=[ingress]
-              )
-    )
-    state_out = t.run(ingress.changed_event)
+    ingress = scenario.Relation(endpoint='ingress', interface='ingress',
+                                remote_app_data={'model': '"bar"', 'port': '42', 'name': '"true"'},
+                                remote_units_data={0: {'bubble': 'blabla', }})
+    t = Tester(scenario.State(leader=True, relations=[ingress]))
+    state_out = t.run(scenario.context.CharmEvents.relation_changed(ingress))
     t.assert_relation_data_empty()
-

--- a/interfaces/ingress/v2/interface_tests/test_provider.py
+++ b/interfaces/ingress/v2/interface_tests/test_provider.py
@@ -1,20 +1,21 @@
 # Copyright 2024 Canonical
 # See LICENSE file for licensing details.
 
-from interface_tester import Tester
 import scenario
-import scenario.context
+from interface_tester import Tester
+
 
 def test_no_data_on_created():
     # nothing happens on created: databags are empty
     t = Tester(
-        scenario.State(leader=True,
+        scenario.State(
+            leader=True,
             relations=[
                 scenario.Relation(
                     endpoint="ingress",
                     interface="ingress",
                 )
-            ]
+            ],
         )
     )
     state_out = t.run("ingress-relation-created")
@@ -24,13 +25,14 @@ def test_no_data_on_created():
 def test_no_data_on_joined():
     # nothing happens on joined: databags are empty
     t = Tester(
-        scenario.State(leader=True,
+        scenario.State(
+            leader=True,
             relations=[
                 scenario.Relation(
                     endpoint="ingress",
                     interface="ingress",
                 )
-            ]
+            ],
         )
     )
     state_out = t.run("ingress-relation-joined")
@@ -38,9 +40,21 @@ def test_no_data_on_joined():
 
 
 def test_data_published_on_changed_remote_valid():
-    relation = scenario.Relation(endpoint='ingress', interface='ingress', remote_app_name='remote',
-                                 remote_app_data={'model': '"bar"', 'port': '42', 'name': '"remote"', },
-                                 remote_units_data={0: {'host': '"0.0.0.42"', }})
+    relation = scenario.Relation(
+        endpoint="ingress",
+        interface="ingress",
+        remote_app_name="remote",
+        remote_app_data={
+            "model": '"bar"',
+            "port": "42",
+            "name": '"remote"',
+        },
+        remote_units_data={
+            0: {
+                "host": '"0.0.0.42"',
+            }
+        },
+    )
     t = Tester(scenario.State(relations=[relation]))
     state_out = t.run(scenario.context.CharmEvents.relation_changed(relation))
     t.assert_schema_valid()
@@ -48,9 +62,20 @@ def test_data_published_on_changed_remote_valid():
 
 def test_data_published_on_changed_remote_invalid_json():
     # on changed, if the remote side has sent invalid json: local side didn't publish anything either.
-    ingress = scenario.Relation(endpoint='ingress', interface='ingress',
-                                remote_app_data={'model': 'bar', 'port': '42', 'name': 'true', },
-                                remote_units_data={0: {'host': '0.0.0.42', }})
+    ingress = scenario.Relation(
+        endpoint="ingress",
+        interface="ingress",
+        remote_app_data={
+            "model": "bar",
+            "port": "42",
+            "name": "true",
+        },
+        remote_units_data={
+            0: {
+                "host": "0.0.0.42",
+            }
+        },
+    )
     t = Tester(scenario.State(leader=True, relations=[ingress]))
     state_out = t.run(scenario.context.CharmEvents.relation_changed(ingress))
     t.assert_relation_data_empty()
@@ -58,9 +83,16 @@ def test_data_published_on_changed_remote_invalid_json():
 
 def test_data_published_on_changed_remote_invalid():
     # on changed, if the remote side has sent invalid data: local side didn't publish anything either.
-    ingress = scenario.Relation(endpoint='ingress', interface='ingress',
-                                remote_app_data={'model': '"bar"', 'port': '42', 'name': '"true"'},
-                                remote_units_data={0: {'bubble': 'blabla', }})
+    ingress = scenario.Relation(
+        endpoint="ingress",
+        interface="ingress",
+        remote_app_data={"model": '"bar"', "port": "42", "name": '"true"'},
+        remote_units_data={
+            0: {
+                "bubble": "blabla",
+            }
+        },
+    )
     t = Tester(scenario.State(leader=True, relations=[ingress]))
     state_out = t.run(scenario.context.CharmEvents.relation_changed(ingress))
     t.assert_relation_data_empty()

--- a/interfaces/prometheus_scrape/v0/interface_tests/test_provider.py
+++ b/interfaces/prometheus_scrape/v0/interface_tests/test_provider.py
@@ -3,7 +3,8 @@
 
 import json
 from interface_tester import Tester
-from scenario import Relation, State
+import scenario
+import scenario.context
 
 
 def test_no_data_on_created():
@@ -73,12 +74,12 @@ valid_app_data["scrape_jobs"] = json.dumps(valid_app_data["scrape_jobs"])
 valid_app_data["alert_rules"] = json.dumps(valid_app_data["alert_rules"])
 
 def test_on_changed_with_existing_valid_data():
-    relation = Relation(
+    relation = scenario.Relation(
         endpoint="prometheus_scrape",
         interface="prometheus_scrape",
         local_app_data=valid_app_data,
         local_unit_data=valid_unit_data,
     )
-    t = Tester(State(relations=[relation]))
-    state_out = t.run(relation.changed_event)
+    t = Tester(scenario.State(relations=[relation]))
+    state_out = t.run(scenario.context.CharmEvents.relation_changed(relation))
     t.assert_schema_valid()

--- a/interfaces/prometheus_scrape/v0/interface_tests/test_provider.py
+++ b/interfaces/prometheus_scrape/v0/interface_tests/test_provider.py
@@ -2,9 +2,9 @@
 # See LICENSE file for licensing details.
 
 import json
-from interface_tester import Tester
+
 import scenario
-import scenario.context
+from interface_tester import Tester
 
 
 def test_no_data_on_created():
@@ -67,11 +67,12 @@ valid_app_data = {
 valid_unit_data = {
     "prometheus_scrape_unit_address": "example-app-0.example-model-endpoints.default.svc.cluster.local",
     "prometheus_scrape_unit_name": "example-app/0",
-    "prometheus_scrape_unit_path": '',
+    "prometheus_scrape_unit_path": "",
 }
 valid_app_data["scrape_metadata"] = json.dumps(valid_app_data["scrape_metadata"])
 valid_app_data["scrape_jobs"] = json.dumps(valid_app_data["scrape_jobs"])
 valid_app_data["alert_rules"] = json.dumps(valid_app_data["alert_rules"])
+
 
 def test_on_changed_with_existing_valid_data():
     relation = scenario.Relation(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ unit_tests = [
     "ops>=2.9",
     "PyYAML>=6.0",
     "pytest>=7.3.1",
-    "ops-scenario<7",
+    "ops-scenario>=5",
 ]
 
 json_schemas = [
@@ -51,7 +51,7 @@ json_schemas = [
 interface_tests = [
     "PyYAML>=6.0",
     "pytest>=7.3.1",
-    "ops-scenario<7",
+    "ops-scenario>=5",
     "requests==2.28.1",
     "virtualenv==20.21.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ keywords = ["juju", "relation interfaces"]
 
 dependencies = [
     "pydantic>2",
-    "pytest-interface-tester>=3.1.0",
+    "pytest-interface-tester>=3.1.1",
     "PyGithub>=2.3.0"
 ]
 
@@ -41,7 +41,7 @@ unit_tests = [
     "ops>=2.9",
     "PyYAML>=6.0",
     "pytest>=7.3.1",
-    "ops-scenario>=5",
+    "ops-scenario==7.0.5",
 ]
 
 json_schemas = [
@@ -51,7 +51,7 @@ json_schemas = [
 interface_tests = [
     "PyYAML>=6.0",
     "pytest>=7.3.1",
-    "ops-scenario>=5",
+    "ops-scenario==7.0.5",
     "requests==2.28.1",
     "virtualenv==20.21.0"
 ]
@@ -73,4 +73,3 @@ profile = "black"
 
 [bdist_wheel]
 universal = 1
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ unit_tests = [
     "ops>=2.9",
     "PyYAML>=6.0",
     "pytest>=7.3.1",
-    "ops-scenario>=5",
+    "ops-scenario<7",
 ]
 
 json_schemas = [
@@ -51,7 +51,7 @@ json_schemas = [
 interface_tests = [
     "PyYAML>=6.0",
     "pytest>=7.3.1",
-    "ops-scenario>=5",
+    "ops-scenario<7",
     "requests==2.28.1",
     "virtualenv==20.21.0"
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -63,8 +63,8 @@ commands =
 [testenv:build-json-schemas]
 description = build json schemas in docs/
 deps =
-    ops==2.6.0
-    ops-scenario<6.0.4 #schema build fails with missing 'CloudCredential' in ops module
+    ops>=2.15.0
+    ops-scenario==7.0.5
     .[json_schemas]
 setenv =
     PYTHONPATH={toxinidir}


### PR DESCRIPTION
Fix failed unit and integration tests due to upgrade to Scenario 7 and fix JSON schema checks (files generated automatically by `tox -e build-json-schemas`).

The scenario version is pinned to 7.0.5, so that future changes won't accidentally break the tests here.

Also fixed version conflicts in tox build-json-schemas.