### PR TITLE
retired tempo-k8s

### DIFF
--- a/interfaces/tracing/v2/interface.yaml
+++ b/interfaces/tracing/v2/interface.yaml
@@ -4,8 +4,6 @@ version: 2
 status: published
 
 providers:
-  - name: tempo-k8s
-    url: https://github.com/canonical/tempo-k8s-operator
   - name: tempo-coordinator-k8s
     url: https://github.com/canonical/tempo-coordinator-k8s-operator
     test_setup:


### PR DESCRIPTION
we're in the process of deprecating and retiring the tempo-k8s charm, replacing it with https://discourse.charmhub.io/t/charmed-tempo-ha/15531

the libs owned by tempo-k8s are now owned by tempo-coordinator-k8s.
