### PR TITLE
fix: assigning issues permission error

### DIFF
--- a/run_matrix.py
+++ b/run_matrix.py
@@ -357,7 +357,7 @@ def create_issue(
 ):
     gh = Github(os.getenv("GITHUB_TOKEN"))
     repo = gh.get_repo("canonical/charm-relation-interfaces")
-    issue_assignee = "IronCore864"
+    issue_assignees = ["IronCore864", "tonyandrewmeyer"]
     workflow_url = ""
     github_run_id = os.getenv("GITHUB_RUN_ID")
     if github_run_id:
@@ -389,7 +389,7 @@ See the workflow {workflow_url} for more detail.
         print(f"GitHub issue updated: {issue.html_url}")
     else:
         issue = repo.create_issue(
-            title=title, body=body, assignee=issue_assignee, labels=labels
+            title=title, body=body, assignees=issue_assignees, labels=labels
         )
         print(f"GitHub issue created: {issue.html_url}")
 

--- a/run_matrix.py
+++ b/run_matrix.py
@@ -378,8 +378,9 @@ See the workflow {workflow_url} for more detail.
             issue = existing_issue
             break
 
-    team_members = get_team_members_from_team_slug(maintainer)
-
+    # Issues in public repositories can have up to 10 people assigned.
+    # https://github.com/canonical/charm-relation-interfaces/actions/runs/11318866281
+    team_members = get_team_members_from_team_slug(maintainer)[:10]
     if issue:
         issue.create_comment(body)
         print(f"GitHub issue updated: {issue.html_url}")

--- a/run_matrix.py
+++ b/run_matrix.py
@@ -357,18 +357,24 @@ def create_issue(
 ):
     gh = Github(os.getenv("GITHUB_TOKEN"))
     repo = gh.get_repo("canonical/charm-relation-interfaces")
+    issue_assignee = "IronCore864"
     workflow_url = ""
     github_run_id = os.getenv("GITHUB_RUN_ID")
     if github_run_id:
         workflow_url = f"https://github.com/canonical/charm-relation-interfaces/actions/runs/{github_run_id}"
     result = flatten_test_result(result_per_role)
     title = f"Interface test for {interface} {version} failed."
+    mention_team_members = ", ".join(
+        ["@" + member for member in get_team_members_from_team_slug(maintainer)]
+    )
     body = f"""\
 Tests for interface {interface} {version} failed.
 
 {result}
 
 See the workflow {workflow_url} for more detail.
+
+{mention_team_members}
 """
 
     issue = None
@@ -378,18 +384,12 @@ See the workflow {workflow_url} for more detail.
             issue = existing_issue
             break
 
-    # Issues in public repositories can have up to 10 people assigned.
-    # https://github.com/canonical/charm-relation-interfaces/actions/runs/11318866281
-    team_members = get_team_members_from_team_slug(maintainer)[:10]
     if issue:
         issue.create_comment(body)
         print(f"GitHub issue updated: {issue.html_url}")
-        if team_members:
-            issue.edit(assignees=team_members)
-            print(f"GitHub issue assigned to {team_members}")
     else:
         issue = repo.create_issue(
-            title=title, body=body, assignees=team_members, labels=labels
+            title=title, body=body, assignee=issue_assignee, labels=labels
         )
         print(f"GitHub issue created: {issue.html_url}")
 


### PR DESCRIPTION
Background: We cannot assign issues to anyone within the Canonical organisation who is not a writer in this repo.

After discussion with Ben, as a workaround, we will create issues, assign them to `charm-tech `members, and then mention the members from the maintainer team in the issue body/comment.

I could not test this change within my personal organisation, so we will have to merge and see how it works. As some manual test, I copy-pasted some of the code in my local console to see the rendered body, which seems fine:

```bash
>>> maintainer="observability"
>>> mention_team_members = ", ".join(["@" + member for member in get_team_members_from_team_slug(maintainer)])
>>> mention_team_members
'@mmkay, @Abuelodelanada, @simskij, @dstathis, @PietroPasotti, @michaeldmitry, @lucabello, @ca-scribner, @IbraAoad, @sed-i, @MichaelThamm'
```