### PR TITLE
feat: add the fiveg_core_gnb interface

### DIFF
--- a/docs/json_schemas/fiveg_core_gnb/v0/provider.json
+++ b/docs/json_schemas/fiveg_core_gnb/v0/provider.json
@@ -70,21 +70,28 @@
           "type": "integer"
         },
         "sd": {
+          "anyOf": [
+            {
+              "maximum": 16777215,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "Slice Differentiator",
           "examples": [
             1
           ],
-          "maximum": 16777215,
-          "minimum": 0,
-          "title": "Sd",
-          "type": "integer"
+          "title": "Sd"
         }
       },
       "required": [
         "mcc",
         "mnc",
-        "sst",
-        "sd"
+        "sst"
       ],
       "title": "PLMNConfig",
       "type": "object"

--- a/docs/json_schemas/fiveg_core_gnb/v0/provider.json
+++ b/docs/json_schemas/fiveg_core_gnb/v0/provider.json
@@ -1,0 +1,94 @@
+{
+  "$defs": {
+    "BaseModel": {
+      "properties": {},
+      "title": "BaseModel",
+      "type": "object"
+    },
+    "FivegGnbIdentityProviderAppData": {
+      "properties": {
+        "mcc": {
+          "description": "Mobile Country Code",
+          "examples": [
+            "001"
+          ],
+          "maxLength": 3,
+          "minLength": 3,
+          "title": "Mcc",
+          "type": "string"
+        },
+        "mnc": {
+          "description": "Mobile Network Code",
+          "examples": [
+            "01"
+          ],
+          "maxLength": 3,
+          "minLength": 2,
+          "title": "Mnc",
+          "type": "string"
+        },
+        "tac": {
+          "description": "Tracking Area Code",
+          "examples": [
+            1
+          ],
+          "maximum": 16777215,
+          "minimum": 1,
+          "title": "Tac",
+          "type": "integer"
+        },
+        "sst": {
+          "description": "Slice Service Type",
+          "examples": [
+            1
+          ],
+          "maximum": 4,
+          "minimum": 1,
+          "title": "Sst",
+          "type": "integer"
+        },
+        "sd": {
+          "description": "Slice Differentiator",
+          "examples": [
+            1
+          ],
+          "maximum": 16777215,
+          "minimum": 1,
+          "title": "Sd",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "mcc",
+        "mnc",
+        "tac",
+        "sst",
+        "sd"
+      ],
+      "title": "FivegGnbIdentityProviderAppData",
+      "type": "object"
+    }
+  },
+  "description": "The schema for the provider side of the fiveg_core_gnb interface.",
+  "properties": {
+    "unit": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BaseModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "app": {
+      "$ref": "#/$defs/FivegGnbIdentityProviderAppData"
+    }
+  },
+  "required": [
+    "app"
+  ],
+  "title": "ProviderSchema",
+  "type": "object"
+}

--- a/docs/json_schemas/fiveg_core_gnb/v0/provider.json
+++ b/docs/json_schemas/fiveg_core_gnb/v0/provider.json
@@ -7,26 +7,6 @@
     },
     "FivegCoreGnbProviderAppData": {
       "properties": {
-        "mcc": {
-          "description": "Mobile Country Code",
-          "examples": [
-            "001"
-          ],
-          "maxLength": 3,
-          "minLength": 3,
-          "title": "Mcc",
-          "type": "string"
-        },
-        "mnc": {
-          "description": "Mobile Network Code",
-          "examples": [
-            "01"
-          ],
-          "maxLength": 3,
-          "minLength": 2,
-          "title": "Mnc",
-          "type": "string"
-        },
         "tac": {
           "description": "Tracking Area Code",
           "examples": [
@@ -37,33 +17,17 @@
           "title": "Tac",
           "type": "integer"
         },
-        "sst": {
-          "description": "Slice Service Type",
-          "examples": [
-            1
-          ],
-          "maximum": 4,
-          "minimum": 1,
-          "title": "Sst",
-          "type": "integer"
-        },
-        "sd": {
-          "description": "Slice Differentiator",
-          "examples": [
-            1
-          ],
-          "maximum": 16777215,
-          "minimum": 1,
-          "title": "Sd",
-          "type": "integer"
+        "plmns": {
+          "items": {
+            "type": "object"
+          },
+          "title": "Plmns",
+          "type": "array"
         }
       },
       "required": [
-        "mcc",
-        "mnc",
         "tac",
-        "sst",
-        "sd"
+        "plmns"
       ],
       "title": "FivegCoreGnbProviderAppData",
       "type": "object"

--- a/docs/json_schemas/fiveg_core_gnb/v0/provider.json
+++ b/docs/json_schemas/fiveg_core_gnb/v0/provider.json
@@ -5,7 +5,7 @@
       "title": "BaseModel",
       "type": "object"
     },
-    "FivegGnbIdentityProviderAppData": {
+    "FivegCoreGnbProviderAppData": {
       "properties": {
         "mcc": {
           "description": "Mobile Country Code",
@@ -65,7 +65,7 @@
         "sst",
         "sd"
       ],
-      "title": "FivegGnbIdentityProviderAppData",
+      "title": "FivegCoreGnbProviderAppData",
       "type": "object"
     }
   },
@@ -83,7 +83,7 @@
       "default": null
     },
     "app": {
-      "$ref": "#/$defs/FivegGnbIdentityProviderAppData"
+      "$ref": "#/$defs/FivegCoreGnbProviderAppData"
     }
   },
   "required": [

--- a/docs/json_schemas/fiveg_core_gnb/v0/provider.json
+++ b/docs/json_schemas/fiveg_core_gnb/v0/provider.json
@@ -19,7 +19,7 @@
         },
         "plmns": {
           "items": {
-            "type": "object"
+            "$ref": "#/$defs/PLMNConfig"
           },
           "title": "Plmns",
           "type": "array"
@@ -30,6 +30,63 @@
         "plmns"
       ],
       "title": "FivegCoreGnbProviderAppData",
+      "type": "object"
+    },
+    "PLMNConfig": {
+      "properties": {
+        "mcc": {
+          "description": "Mobile Country Code",
+          "examples": [
+            "001",
+            "208",
+            "302"
+          ],
+          "pattern": "[0-9][0-9][0-9]",
+          "title": "Mcc",
+          "type": "string"
+        },
+        "mnc": {
+          "description": "Mobile Network Code",
+          "examples": [
+            "01",
+            "001",
+            "999"
+          ],
+          "pattern": "[0-9][0-9][0-9]?",
+          "title": "Mnc",
+          "type": "string"
+        },
+        "sst": {
+          "description": "Slice/Service Type",
+          "examples": [
+            1,
+            2,
+            3,
+            4
+          ],
+          "maximum": 255,
+          "minimum": 0,
+          "title": "Sst",
+          "type": "integer"
+        },
+        "sd": {
+          "description": "Slice Differentiator",
+          "examples": [
+            1
+          ],
+          "maximum": 16777215,
+          "minimum": 0,
+          "title": "Sd",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "mcc",
+        "mnc",
+        "sst",
+        "sd"
+      ],
+      "title": "PLMNConfig",
       "type": "object"
     }
   },

--- a/docs/json_schemas/fiveg_core_gnb/v0/requirer.json
+++ b/docs/json_schemas/fiveg_core_gnb/v0/requirer.json
@@ -7,17 +7,17 @@
     },
     "FivegCoreGnbRequirerAppData": {
       "properties": {
-        "cu_id": {
+        "cu_name": {
           "description": "Unique identifier of the CU/gnB.",
           "examples": [
             "gnb001"
           ],
-          "title": "Cu Id",
+          "title": "Cu Name",
           "type": "string"
         }
       },
       "required": [
-        "cu_id"
+        "cu_name"
       ],
       "title": "FivegCoreGnbRequirerAppData",
       "type": "object"

--- a/docs/json_schemas/fiveg_core_gnb/v0/requirer.json
+++ b/docs/json_schemas/fiveg_core_gnb/v0/requirer.json
@@ -5,7 +5,7 @@
       "title": "BaseModel",
       "type": "object"
     },
-    "FivegGnbIdentityRequirerAppData": {
+    "FivegCoreGnbRequirerAppData": {
       "properties": {
         "cu_id": {
           "description": "Unique identifier of the CU/gnB.",
@@ -19,7 +19,7 @@
       "required": [
         "cu_id"
       ],
-      "title": "FivegGnbIdentityRequirerAppData",
+      "title": "FivegCoreGnbRequirerAppData",
       "type": "object"
     }
   },
@@ -37,7 +37,7 @@
       "default": null
     },
     "app": {
-      "$ref": "#/$defs/FivegGnbIdentityRequirerAppData"
+      "$ref": "#/$defs/FivegCoreGnbRequirerAppData"
     }
   },
   "required": [

--- a/docs/json_schemas/fiveg_core_gnb/v0/requirer.json
+++ b/docs/json_schemas/fiveg_core_gnb/v0/requirer.json
@@ -1,0 +1,48 @@
+{
+  "$defs": {
+    "BaseModel": {
+      "properties": {},
+      "title": "BaseModel",
+      "type": "object"
+    },
+    "FivegGnbIdentityRequirerAppData": {
+      "properties": {
+        "cu_id": {
+          "description": "Unique identifier of the CU/gnB.",
+          "examples": [
+            "gnb001"
+          ],
+          "title": "Cu Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "cu_id"
+      ],
+      "title": "FivegGnbIdentityRequirerAppData",
+      "type": "object"
+    }
+  },
+  "description": "The schema for the requirer side of the fiveg_core_gnb interface.",
+  "properties": {
+    "unit": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BaseModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "app": {
+      "$ref": "#/$defs/FivegGnbIdentityRequirerAppData"
+    }
+  },
+  "required": [
+    "app"
+  ],
+  "title": "RequirerSchema",
+  "type": "object"
+}

--- a/interfaces/fiveg_core_gnb/v0/README.md
+++ b/interfaces/fiveg_core_gnb/v0/README.md
@@ -13,7 +13,7 @@ In a typical 5G network, the provider of this interface would be a CU or a gNode
 ```mermaid
 flowchart TD
     Provider -- MCC, MNC, TAC, SST, SD --> Requirer
-    Required -- CU/gNodeB Identifier --> Provider
+    Requirer -- CU/gNodeB Identifier --> Provider
 ```
 
 As with all Juju relations, the `fiveg_core_gnb` interface consists of two parties: a Provider and a Requirer.
@@ -25,9 +25,12 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
 ### Provider
 
 - Is expected to provide the following data:
+  - TAC (Tracking Area Code)
+  - List of PLMNs
+
+The list of PLMNs should include the following data:
   - MCC (Mobile Country Code)
   - MNC (Mobile Network Code)
-  - TAC (Tracking Area Code)
   - SST (Slice Service Type)
   - SD (Slice Differentiator)
     
@@ -45,16 +48,20 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
 ```yaml
 provider:
   app: {
-    "mcc": "001",
-    "mnc": "01",
     "tac": 1,
-    "sst": 1,
-    "sd": 1
+    "plmns": [
+      {
+        "mcc": "001",
+        "mnc": "01",
+        "sst": 1,
+        "sd": 1,
+      }
+    ],
   }
   unit: {}
 requirer:
   app: {
-    "cu_id": "gnb001"
+    "cu_name": "gnb001"
   }
   unit: {}
 ```

--- a/interfaces/fiveg_core_gnb/v0/README.md
+++ b/interfaces/fiveg_core_gnb/v0/README.md
@@ -1,0 +1,60 @@
+# `fiveg_core_gnb`
+
+## Usage
+
+Within 5G, the CU is the Central Unit of a RAN (Radio Access Network) and needs to be configured according to the 5G network parameters.
+
+The `fiveg_core_gnb` relation interface describes the expected behavior of any charm claiming to be able to provide or consume the CU (or gNodeB) configuration information.
+
+In a typical 5G network, the provider of this interface would be a CU or a gNodeB. The requirer of this interface would be the NMS (Network Management System).
+
+## Direction
+
+```mermaid
+flowchart TD
+    Provider -- MCC, MNC, TAC, SST, SD --> Requirer
+    Required -- CU/gNodeB Identifier --> Provider
+```
+
+As with all Juju relations, the `fiveg_core_gnb` interface consists of two parties: a Provider and a Requirer.
+
+## Behavior
+
+Both the Requirer and the Provider need to adhere to criteria to be considered compatible with the interface.
+
+### Provider
+
+- Is expected to provide the following data:
+  - MCC (Mobile Country Code)
+  - MNC (Mobile Network Code)
+  - TAC (Tracking Area Code)
+  - SST (Slice Service Type)
+  - SD (Slice Differentiator)
+    
+
+### Requirer
+
+- Is expected to provide a unique identifier of the CU (or gNodeB).
+
+## Relation Data
+
+[\[Pydantic Schema\]](./schema.py)
+
+#### Example
+
+```yaml
+provider:
+  app: {
+    "mcc": "001",
+    "mnc": "01",
+    "tac": 1,
+    "sst": 1,
+    "sd": 1
+  }
+  unit: {}
+requirer:
+  app: {
+    "cu_id": "gnb001"
+  }
+  unit: {}
+```

--- a/interfaces/fiveg_core_gnb/v0/interface.yaml
+++ b/interfaces/fiveg_core_gnb/v0/interface.yaml
@@ -1,0 +1,12 @@
+name: fiveg_core_gnb
+internal: true
+
+version: 0
+status: draft
+
+providers:
+  - name: sdcore-nms-k8s-operator
+    url: https://github.com/canonical/sdcore-nms-k8s-operator
+requirers: []
+
+maintainer: telco

--- a/interfaces/fiveg_core_gnb/v0/interface.yaml
+++ b/interfaces/fiveg_core_gnb/v0/interface.yaml
@@ -7,6 +7,8 @@ status: draft
 providers:
   - name: sdcore-nms-k8s-operator
     url: https://github.com/canonical/sdcore-nms-k8s-operator
-requirers: []
+requirers:
+  - name: sdcore-gnbsim-k8s-operator
+    url: https://github.com/canonical/sdcore-gnbsim-k8s-operator
 
 maintainer: telco

--- a/interfaces/fiveg_core_gnb/v0/schema.py
+++ b/interfaces/fiveg_core_gnb/v0/schema.py
@@ -25,9 +25,38 @@ Examples:
         }
 """
 
+from dataclasses import dataclass
 from interface_tester.schema_base import DataBagSchema
 from pydantic import BaseModel, Field
 from typing import List
+
+
+@dataclass
+class PLMNConfig:
+    """Dataclass representing the configuration for a PLMN."""
+
+    mcc: str = Field(
+        description="Mobile Country Code",
+        examples=["001", "208", "302"],
+        pattern=r"[0-9][0-9][0-9]",
+    )
+    mnc: str = Field(
+        description="Mobile Network Code",
+        examples=["01", "001", "999"],
+        pattern=r"[0-9][0-9][0-9]?",
+    )
+    sst: int = Field(
+        description="Slice/Service Type",
+        examples=[1, 2, 3, 4],
+        ge=0,
+        le=255,
+    )
+    sd: int = Field(
+        description="Slice Differentiator",
+        examples=[1],
+        ge=0,
+        le=16777215,
+    )
 
 
 class FivegCoreGnbProviderAppData(BaseModel):
@@ -37,7 +66,7 @@ class FivegCoreGnbProviderAppData(BaseModel):
         ge=1,
         le=16777215,
     )
-    plmns: List[dict]
+    plmns: List[PLMNConfig]
 
 
 class FivegCoreGnbRequirerAppData(BaseModel):

--- a/interfaces/fiveg_core_gnb/v0/schema.py
+++ b/interfaces/fiveg_core_gnb/v0/schema.py
@@ -1,0 +1,75 @@
+"""This file defines the schemas for the provider and requirer sides of the `fiveg_core_gnb` relation interface.
+
+It must expose two interfaces.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {
+            "mcc": "001",
+            "mnc": "01",
+            "tac": 1,
+            "sst": 1,
+            "sd": 1,
+        }
+    RequirerSchema:
+        unit: <empty>
+        app: {
+            "cu_id": "gnb001",
+        }
+"""
+
+from interface_tester.schema_base import DataBagSchema
+from pydantic import BaseModel, Field
+
+
+class FivegGnbIdentityProviderAppData(BaseModel):
+    mcc: str = Field(
+        description="Mobile Country Code",
+        examples=["001"],
+        min_length=3,
+        max_length=3,
+    )
+    mnc: str = Field(
+        description="Mobile Network Code",
+        examples=["01"],
+        min_length=2,
+        max_length=3,
+    )
+    tac: int = Field(
+        description="Tracking Area Code",
+        examples=[1],
+        ge=1,
+        le=16777215,
+    )
+    sst: int = Field(
+        description="Slice Service Type",
+        examples=[1],
+        ge=1,
+        le=4,
+    )
+    sd: int = Field(
+        description="Slice Differentiator",
+        examples=[1],
+        ge=1,
+        le=16777215,
+    )
+
+
+class FivegGnbIdentityRequirerAppData(BaseModel):
+    cu_id: str = Field(
+        description="Unique identifier of the CU/gnB.",
+        examples=["gnb001"]
+    )
+
+
+class ProviderSchema(DataBagSchema):
+    """The schema for the provider side of the fiveg_core_gnb interface."""
+    app: FivegGnbIdentityProviderAppData
+
+
+class RequirerSchema(DataBagSchema):
+    """The schema for the requirer side of the fiveg_core_gnb interface."""
+    app: FivegGnbIdentityRequirerAppData

--- a/interfaces/fiveg_core_gnb/v0/schema.py
+++ b/interfaces/fiveg_core_gnb/v0/schema.py
@@ -21,7 +21,7 @@ Examples:
     RequirerSchema:
         unit: <empty>
         app: {
-            "cu_id": "gnb001",
+            "cu_name": "gnb001",
         }
 """
 
@@ -41,7 +41,7 @@ class FivegCoreGnbProviderAppData(BaseModel):
 
 
 class FivegCoreGnbRequirerAppData(BaseModel):
-    cu_id: str = Field(
+    cu_name: str = Field(
         description="Unique identifier of the CU/gnB.",
         examples=["gnb001"]
     )

--- a/interfaces/fiveg_core_gnb/v0/schema.py
+++ b/interfaces/fiveg_core_gnb/v0/schema.py
@@ -28,7 +28,7 @@ Examples:
 from dataclasses import dataclass
 from interface_tester.schema_base import DataBagSchema
 from pydantic import BaseModel, Field
-from typing import List
+from typing import List, Optional
 
 
 @dataclass
@@ -51,8 +51,9 @@ class PLMNConfig:
         ge=0,
         le=255,
     )
-    sd: int = Field(
+    sd: Optional[int] = Field(
         description="Slice Differentiator",
+        default=None,
         examples=[1],
         ge=0,
         le=16777215,

--- a/interfaces/fiveg_core_gnb/v0/schema.py
+++ b/interfaces/fiveg_core_gnb/v0/schema.py
@@ -27,6 +27,7 @@ Examples:
 
 from interface_tester.schema_base import DataBagSchema
 from pydantic import BaseModel, Field
+from typing import List
 
 
 class FivegCoreGnbProviderAppData(BaseModel):
@@ -36,7 +37,7 @@ class FivegCoreGnbProviderAppData(BaseModel):
         ge=1,
         le=16777215,
     )
-    plmns: list[dict]
+    plmns: List[dict]
 
 
 class FivegCoreGnbRequirerAppData(BaseModel):

--- a/interfaces/fiveg_core_gnb/v0/schema.py
+++ b/interfaces/fiveg_core_gnb/v0/schema.py
@@ -8,11 +8,15 @@ Examples:
     ProviderSchema:
         unit: <empty>
         app: {
-            "mcc": "001",
-            "mnc": "01",
             "tac": 1,
-            "sst": 1,
-            "sd": 1,
+            "plmns": [
+                {
+                    "mcc": "001",
+                    "mnc": "01",
+                    "sst": 1,
+                    "sd": 1,
+                }
+            ],
         }
     RequirerSchema:
         unit: <empty>
@@ -26,36 +30,13 @@ from pydantic import BaseModel, Field
 
 
 class FivegCoreGnbProviderAppData(BaseModel):
-    mcc: str = Field(
-        description="Mobile Country Code",
-        examples=["001"],
-        min_length=3,
-        max_length=3,
-    )
-    mnc: str = Field(
-        description="Mobile Network Code",
-        examples=["01"],
-        min_length=2,
-        max_length=3,
-    )
     tac: int = Field(
         description="Tracking Area Code",
         examples=[1],
         ge=1,
         le=16777215,
     )
-    sst: int = Field(
-        description="Slice Service Type",
-        examples=[1],
-        ge=1,
-        le=4,
-    )
-    sd: int = Field(
-        description="Slice Differentiator",
-        examples=[1],
-        ge=1,
-        le=16777215,
-    )
+    plmns: list[dict]
 
 
 class FivegCoreGnbRequirerAppData(BaseModel):

--- a/interfaces/fiveg_core_gnb/v0/schema.py
+++ b/interfaces/fiveg_core_gnb/v0/schema.py
@@ -25,7 +25,7 @@ from interface_tester.schema_base import DataBagSchema
 from pydantic import BaseModel, Field
 
 
-class FivegGnbIdentityProviderAppData(BaseModel):
+class FivegCoreGnbProviderAppData(BaseModel):
     mcc: str = Field(
         description="Mobile Country Code",
         examples=["001"],
@@ -58,7 +58,7 @@ class FivegGnbIdentityProviderAppData(BaseModel):
     )
 
 
-class FivegGnbIdentityRequirerAppData(BaseModel):
+class FivegCoreGnbRequirerAppData(BaseModel):
     cu_id: str = Field(
         description="Unique identifier of the CU/gnB.",
         examples=["gnb001"]
@@ -67,9 +67,9 @@ class FivegGnbIdentityRequirerAppData(BaseModel):
 
 class ProviderSchema(DataBagSchema):
     """The schema for the provider side of the fiveg_core_gnb interface."""
-    app: FivegGnbIdentityProviderAppData
+    app: FivegCoreGnbProviderAppData
 
 
 class RequirerSchema(DataBagSchema):
     """The schema for the requirer side of the fiveg_core_gnb interface."""
-    app: FivegGnbIdentityRequirerAppData
+    app: FivegCoreGnbRequirerAppData


### PR DESCRIPTION
This PR adds definition of the `fiveg_core_gnb` interface, according to the [TE126 - Orchestrating network configuration between the Core and the RAN](https://docs.google.com/document/d/1YsPgqfRDd9NX8j-BtJL4psvR1EJ7vTOvJGwm9k3iH_c/) specification.

This interface will be used by NMS (Network Management System) to configure the CUs (Central Unit) or gNodeBs, components of the RAN (Radio Access Network) in a 5G Network.