### PR TITLE
chore: update saml and smtp interfaces maintainer

### DIFF
--- a/interfaces/saml/v0/interface.yaml
+++ b/interfaces/saml/v0/interface.yaml
@@ -10,4 +10,4 @@ providers:
 requirers:
   []
 
-maintainer: identity
+maintainer: is-charms

--- a/interfaces/smtp/v0/interface.yaml
+++ b/interfaces/smtp/v0/interface.yaml
@@ -10,4 +10,4 @@ providers:
 requirers:
   []
 
-maintainer: identity
+maintainer: is-charms


### PR DESCRIPTION
[From commit history](https://github.com/canonical/charm-relation-interfaces/tree/4ebec2b8aeb1a724639ca4dfde4be92bf98cb447), both smtp and saml interfaces are maintained by the IAM team, but as confirmed by Massimiliano and David, the maintainer/owners of these two interfaces are the `platform-engineering` team. This team hasn't been created/updated in GitHub orgs yet, so at the moment, as confirmed by David, we set the maintainers as the `is-charms` team.