### PR TITLE
feat: Extend fiveg_rfsim interface

### DIFF
--- a/docs/json_schemas/fiveg_rfsim/v0/provider.json
+++ b/docs/json_schemas/fiveg_rfsim/v0/provider.json
@@ -14,10 +14,42 @@
           ],
           "title": "Rfsim Address",
           "type": "string"
+        },
+        "sst": {
+          "description": "Slice/Service Type",
+          "examples": [
+            1,
+            2,
+            3,
+            4
+          ],
+          "maximum": 255,
+          "minimum": 0,
+          "title": "Sst",
+          "type": "integer"
+        },
+        "sd": {
+          "anyOf": [
+            {
+              "maximum": 16777215,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Slice Differentiator",
+          "examples": [
+            1
+          ],
+          "title": "Sd"
         }
       },
       "required": [
-        "rfsim_address"
+        "rfsim_address",
+        "sst"
       ],
       "title": "FivegRFSIMProviderAppData",
       "type": "object"

--- a/interfaces/fiveg_rfsim/v0/README.md
+++ b/interfaces/fiveg_rfsim/v0/README.md
@@ -12,7 +12,7 @@ This relation interface describes the expected behavior of charms claiming to be
 
 ```mermaid
 flowchart TD
-    Provider -- RFSIM address, SST, SD --> Requirer
+    Provider -- rfsim_address, sst, sd --> Requirer
 ```
 
 As with all Juju relations, the `fiveg_rfsim` interface consists of two parties: a Provider and a Requirer.

--- a/interfaces/fiveg_rfsim/v0/README.md
+++ b/interfaces/fiveg_rfsim/v0/README.md
@@ -40,7 +40,7 @@ provider:
   app: {
     "rfsim_address": "192.168.70.130",
     "sst": 1,
-    "sd", 1,
+     "sd": 1,
   }
   unit: {}
 requirer:

--- a/interfaces/fiveg_rfsim/v0/README.md
+++ b/interfaces/fiveg_rfsim/v0/README.md
@@ -4,7 +4,7 @@
 
 Within 5G RAN (Radio Access Network) architecture, the OAI DU charm can be started to act as both the DU and the RU through its RF simulator functionality. 
 
-The OAI UE charm requires RF simulator address and the network information in order to connect. Hence, the provider of this interface would be a OAI DU charm and the requirer of this interface would be the OAI UE charm.
+The OAI UE charm requires RF simulator address and the network information(SST, SD) in order to connect. Hence, the provider of this interface would be a OAI DU charm and the requirer of this interface would be the OAI UE charm.
 
 This relation interface describes the expected behavior of charms claiming to be able to provide or consume information on connectivity over the fiveg_rfsim interface.
 
@@ -23,11 +23,15 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
 
 ### Provider
 
-- Is expected to provide the DU's `rfsim` service ip.
+Is expected to provide following information:
+
+- The DU's `rfsim` service ip
+- Network Slice/Service Type (SST)
+- Slice Differentiator (SD)
 
 ### Requirer
 
-- Is expected to use the `rfsim` service address passed by the provider.
+- Is expected to use the `rfsim` service address and the network information(SST, SD) passed by the provider.
 
 ## Relation Data
 

--- a/interfaces/fiveg_rfsim/v0/README.md
+++ b/interfaces/fiveg_rfsim/v0/README.md
@@ -4,7 +4,7 @@
 
 Within 5G RAN (Radio Access Network) architecture, the OAI DU charm can be started to act as both the DU and the RU through its RF simulator functionality. 
 
-The OAI UE charm requires RF simulator address in order to connect. Hence, the provider of this interface would be a OAI DU charm and the requirer of this interface would be the OAI UE charm.
+The OAI UE charm requires RF simulator address and the network information in order to connect. Hence, the provider of this interface would be a OAI DU charm and the requirer of this interface would be the OAI UE charm.
 
 This relation interface describes the expected behavior of charms claiming to be able to provide or consume information on connectivity over the fiveg_rfsim interface.
 
@@ -12,7 +12,7 @@ This relation interface describes the expected behavior of charms claiming to be
 
 ```mermaid
 flowchart TD
-    Provider -- rfsim_address --> Requirer
+    Provider -- RFSIM address, SST, SD --> Requirer
 ```
 
 As with all Juju relations, the `fiveg_rfsim` interface consists of two parties: a Provider and a Requirer.
@@ -39,6 +39,8 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
 provider:
   app: {
     "rfsim_address": "192.168.70.130",
+    "sst": 1,
+    "sd", 1,
   }
   unit: {}
 requirer:

--- a/interfaces/fiveg_rfsim/v0/schema.py
+++ b/interfaces/fiveg_rfsim/v0/schema.py
@@ -7,11 +7,14 @@ Examples:
         unit: <empty>
         app: {
             "rfsim_address": "192.168.70.130",
+            "sst": 1,
+            "sd": 1,
         }
     RequirerSchema:
         unit: <empty>
         app:  <empty>
 """
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -23,6 +26,20 @@ class FivegRFSIMProviderAppData(BaseModel):
         description="RF simulator service ip",
         examples=["192.168.70.130"]
     )
+    sst: int = Field(
+        description="Slice/Service Type",
+        examples=[1, 2, 3, 4],
+        ge=0,
+        le=255,
+    )
+    sd: Optional[int] = Field(
+        description="Slice Differentiator",
+        default=None,
+        examples=[1],
+        ge=0,
+        le=16777215,
+    )
+
 
 class ProviderSchema(DataBagSchema):
     """Provider schema for the fiveg_rfsim interface."""


### PR DESCRIPTION
This PR extends the fiveg_rfsim interface according to the [TE126 - Orchestrating network configuration between the Core and the RAN](https://docs.google.com/document/d/1YsPgqfRDd9NX8j-BtJL4psvR1EJ7vTOvJGwm9k3iH_c/) specification.

This interface is only used internally between the DUs (Distributed Unit) and the UEs (User equipment) to orchestrate network configuration for the Charmed Aether SD-Core.