### PR TITLE
added grafana uid

### DIFF
--- a/docs/json_schemas/grafana_datasource/v0/requirer.json
+++ b/docs/json_schemas/grafana_datasource/v0/requirer.json
@@ -18,10 +18,19 @@
           },
           "title": "Datasource Uids",
           "type": "string"
+        },
+        "grafana_uid": {
+          "description": "UID of the requirer application.",
+          "examples": [
+            "foo-0000-0000-0000-0000-grafana-1"
+          ],
+          "title": "Grafana Uid",
+          "type": "string"
         }
       },
       "required": [
-        "datasource_uids"
+        "datasource_uids",
+        "grafana_uid"
       ],
       "title": "GrafanaSourceRequirerAppData",
       "type": "object"

--- a/docs/json_schemas/grafana_datasource_exchange/v0/provider.json
+++ b/docs/json_schemas/grafana_datasource_exchange/v0/provider.json
@@ -22,11 +22,17 @@
           "description": "Grafana datasource UID, as assigned by Grafana.",
           "title": "Uid",
           "type": "string"
+        },
+        "grafana_uid": {
+          "description": "Grafana UID.",
+          "title": "Grafana Uid",
+          "type": "string"
         }
       },
       "required": [
         "type",
-        "uid"
+        "uid",
+        "grafana_uid"
       ],
       "title": "GrafanaDatasource",
       "type": "object"

--- a/docs/json_schemas/grafana_datasource_exchange/v0/requirer.json
+++ b/docs/json_schemas/grafana_datasource_exchange/v0/requirer.json
@@ -22,11 +22,17 @@
           "description": "Grafana datasource UID, as assigned by Grafana.",
           "title": "Uid",
           "type": "string"
+        },
+        "grafana_uid": {
+          "description": "Grafana UID.",
+          "title": "Grafana Uid",
+          "type": "string"
         }
       },
       "required": [
         "type",
-        "uid"
+        "uid",
+        "grafana_uid"
       ],
       "title": "GrafanaDatasource",
       "type": "object"

--- a/interfaces/grafana_datasource/v0/README.md
+++ b/interfaces/grafana_datasource/v0/README.md
@@ -10,12 +10,14 @@ In most cases, this will be accomplished using the [grafana_source library](http
 The `grafana_datasource` interface implements a provider/requirer pattern.
 The provider is a charm that implements a grafana datasource-compatible endpoint, and the requirer is a charm that is able to use such an endpoint to query the data.
 
-The requirer is furthermore expected to share back to the provider a unique identifier assigned to the source. This can be used by the provider to share with other charms for data correlation and cross-referencing purposes.
+The requirer is furthermore expected to share back to the provider:
+- a unique identifier assigned to the source. This can be used by the provider to share with other charms for data correlation and cross-referencing purposes.
+- a unique identifier for the grafana application itself.
 
 ```mermaid
 flowchart TD
     Provider -- DatasourceEndpoint --> Requirer
-    Requirer -- DatasourceUID --> Provider
+    Requirer -- [DatasourceUID,GrafanaUID] --> Provider
 ```
 
 ## Behavior
@@ -30,6 +32,7 @@ The requirer and the provider need to adhere to a certain set of criteria to be 
 ### Requirer
 
 - Is expected to share back via application data a mapping from provider unit names to unique datasource IDs. 
+- Is expected to share back via application data a unique ID for the grafana application.
 
 ## Relation Data
 
@@ -73,10 +76,12 @@ application_data: {
 
 The provider is expected to share back a unique identifier for each unit of the requirer, as a mapping.
 This will be encoded as a json dict and nested under the `datasource_uids` field in the application databag.
+Also, is expected to share back a unique ID for the grafana application.
 
 #### Example
 ```yaml
 application-data: {
+ grafana_uid: 0000-0000-0000-0000,
  datasource_uids: {
   "tempo/0": 0000-0000-0000-0001, 
   "tempo/1": 0000-0000-0000-0002,

--- a/interfaces/grafana_datasource/v0/interface_tests/test_requirer.py
+++ b/interfaces/grafana_datasource/v0/interface_tests/test_requirer.py
@@ -76,5 +76,3 @@ def test_datasource_uid_shared_if_remote_data_valid():
     # each requirer unit has received a datasource uid
     assert ds_uids['foo/0']
     assert ds_uids['foo/42']
-
-

--- a/interfaces/grafana_datasource/v0/schema.py
+++ b/interfaces/grafana_datasource/v0/schema.py
@@ -41,6 +41,10 @@ class ProviderSchema(DataBagSchema):
 class GrafanaSourceRequirerAppData(BaseModel):
     """Application databag model for the requirer side of this interface."""
     datasource_uids: Json[Dict[str, str]]
+    grafana_uid: str = Field(
+        description="UID of the requirer application.",
+        examples=['foo-0000-0000-0000-0000-grafana-1']
+    )
 
 
 class RequirerSchema(DataBagSchema):

--- a/interfaces/grafana_datasource_exchange/v0/README.md
+++ b/interfaces/grafana_datasource_exchange/v0/README.md
@@ -30,7 +30,8 @@ The requirer and the provider need to adhere to a certain set of criteria to be 
 - Is expected to register each datasource endpoint (one per unit) with a central grafana application and obtain a Datasource UID for each one of them. 
 - Is expected to share via application data, as a json-encoded array (sorted by UID), the following information:
   - for each datasource (which technically will likely mean, for each unit of the application):
-    - the datasource UID: an arbitrary string, that is expected to be unique for the grafana instance
+    - the datasource UID: an arbitrary string, uniquely identifying the datasource
+    - the grafana UID: an arbitrary string uniquely identifying a grafana instance
     - the datasource type: a grafana datasource type name (typically will be [one of the built-in ones](https://grafana.com/docs/grafana/latest/datasources/#built-in-core-data-sources))
     
 To avoid complexity, we stipulate that the data will be provided in bulk: only 'fully specified' datasources will be shared, i.e. this is not a valid databag state:
@@ -62,11 +63,13 @@ application_data: {
     [
       {
         type: tempo,
-        uid: 0000-0000-0000-0001
+        uid: 0000-0000-0000-0001,
+        grafana_uid: 0000-0000-0000-0002,
       },
       {
         type: prometheus,
-        uid: 0000-0000-0000-0002
+        uid: 0000-0000-0000-0003,
+        grafana_uid: 0000-0000-0000-0004,
       },
     ]
 }

--- a/interfaces/grafana_datasource_exchange/v0/interface_tests/test_provider.py
+++ b/interfaces/grafana_datasource_exchange/v0/interface_tests/test_provider.py
@@ -1,5 +1,3 @@
-import json
-
 from interface_tester import Tester
 from scenario import State, Relation
 

--- a/interfaces/grafana_datasource_exchange/v0/interface_tests/test_requirer.py
+++ b/interfaces/grafana_datasource_exchange/v0/interface_tests/test_requirer.py
@@ -1,2 +1,20 @@
-# given that this interface is symmetric, and we expect each provider
-# to also be a requirer, we omit the requirer tests.
+from interface_tester import Tester
+from scenario import State, Relation
+
+
+def test_datasource_exchange():
+    # GIVEN the grafana_datasource interface has shared one or more source UIDs
+    source_exchange = Relation(
+        endpoint='grafana-source-exchange',
+        interface='grafana_datasource_exchange',
+        remote_app_name='bar'
+    )
+    tester = Tester(state_in=State(
+        relations=[
+            source_exchange
+        ]
+    ))
+    # WHEN the requirer processes any relation event
+    tester.run('grafana-source-exchange-relation-changed')
+    # THEN the requirer publishes valid data
+    tester.assert_schema_valid()

--- a/interfaces/grafana_datasource_exchange/v0/schema.py
+++ b/interfaces/grafana_datasource_exchange/v0/schema.py
@@ -9,6 +9,7 @@ class GrafanaDatasource(BaseModel):
                                   "https://grafana.com/docs/grafana/latest/datasources/#built-in-core-data-sources.",
                       examples=["tempo", "loki", "prometheus", "elasticsearch"])
     uid: str = Field(description="Grafana datasource UID, as assigned by Grafana.")
+    grafana_uid: str = Field(description="Grafana UID.")
 
 
 class GrafanaSourceAppData(BaseModel):


### PR DESCRIPTION
Adds an identifier for the grafana instance on which the datasource is registered, so the datasources themselves can determine whether cross-comparing will have any sense, because their datasources are known to the same Grafana instance (or not).

reference implementation: https://github.com/canonical/grafana-k8s-operator/compare/main...add-grafana-uid-to-DS

