### PR TITLE
fix(ldap): update `url: AnyURL` to `urls: list[AnyURL]`

### DIFF
--- a/docs/json_schemas/ldap/v0/provider.json
+++ b/docs/json_schemas/ldap/v0/provider.json
@@ -7,13 +7,19 @@
     },
     "LdapProviderData": {
       "properties": {
-        "url": {
-          "description": "The LDAP URL",
-          "example": "ldap://ldap.canonical.com:3893",
-          "format": "uri",
-          "minLength": 1,
-          "title": "LDAP URL",
-          "type": "string"
+        "urls": {
+          "description": "List of LDAP URLs",
+          "example": [
+            "ldap://ldap.canonical.com:3893",
+            "ldap://ldap.ubuntu.com:3893"
+          ],
+          "items": {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "LDAP URLs",
+          "type": "array"
         },
         "base_dn": {
           "description": "The base entry as the starting point for LDAP search operation",
@@ -47,7 +53,7 @@
         }
       },
       "required": [
-        "url",
+        "urls",
         "base_dn",
         "bind_dn",
         "bind_password_secret",

--- a/interfaces/ldap/v0/README.md
+++ b/interfaces/ldap/v0/README.md
@@ -17,7 +17,7 @@ be able to provide or consume the LDAP authentication configuration data.
 ```mermaid
 flowchart TD
     Requirer -- user, \ngroup --> Provider
-    Provider -- url, \nbase_dn, \nbind_dn, \nbind_password_secret, \nauth_method, \nstarttls --> Requirer
+    Provider -- urls, \nbase_dn, \nbind_dn, \nbind_password_secret, \nauth_method, \nstarttls --> Requirer
 ```
 
 ## Behavior
@@ -66,7 +66,7 @@ It should be placed in the **application** databag.
     - endpoint: ldap
       related-endpoint: ldap
       application-data:
-        url: ldap://ldap.canonical.com:3893
+        urls: [ldap://ldap.canonical.com:3893, ldap://ldap.ubuntu.com:3893]
         base_dn: dc=canonical,dc=com
         bind_dn: cn=app,ou=model,dc=canonical,dc=com
         bind_password_secret: secret://59060ecc-0495-4a80-8006-5f1fc13fd783/cjqub6vubg2s77p3nio0

--- a/interfaces/ldap/v0/interface.yaml
+++ b/interfaces/ldap/v0/interface.yaml
@@ -5,6 +5,8 @@ status: draft
 providers:
   - name: glauth-k8s
     url: https://github.com/canonical/glauth-k8s-operator
-requirers: []
+requirers:
+  - name: sssd
+    url: https://github.com/canonical/sssd-operator
 
 maintainer: identity

--- a/interfaces/ldap/v0/schema.py
+++ b/interfaces/ldap/v0/schema.py
@@ -6,17 +6,17 @@ It must expose two interfaces.schema_base.DataBagSchema subclasses called:
 - RequirerSchema
 """
 
-from typing import Optional
+from typing import List, Optional
 
 from interface_tester.schema_base import DataBagSchema
 from pydantic import AnyUrl, BaseModel, Field
 
 
 class LdapProviderData(BaseModel):
-    url: AnyUrl = Field(
-        description="The LDAP URL",
-        title="LDAP URL",
-        example="ldap://ldap.canonical.com:3893",
+    urls: List[AnyUrl] = Field(
+        description="List of LDAP URLs",
+        title="LDAP URLs",
+        example=["ldap://ldap.canonical.com:3893", "ldap://ldap.ubuntu.com:3893"],
     )
     base_dn: str = Field(
         description="The base entry as the starting point for LDAP search "


### PR DESCRIPTION
Small PR that corrects the `ldap` interface. The interface originally had the `url` field typed as `url: AnyURL`, however, the `url` field is now actually the `urls` field as is typed as `list[AnyURL]`. Providers like glauth-k8s can provide multiple LDAP server URLs now rather than just one. Here's the relevant block of code in the `ldap` library implementation:

https://github.com/canonical/glauth-k8s-operator/blob/73209477bd4ef533b88f543d4c7c24a7bf9dffee/lib/charms/glauth_k8s/v0/ldap.py#L230-L231

Providing multiple server URLs is necessary for HA GLAuth deployments where each GLAuth instance runs independently and uses an HA backing database such as Postgres or MySQL: https://glauth.github.io/docs/high-availability.html

Also, I added the SSSD operator as an example implementation of a requirer in _interface.yaml_

CC @wood-push-melon :eyes:

> ~~Also, let me know if `list[AnyURL]` is the proper annotation to use here with `pydantic`/`interface_tester`. [`typing.List` is deprecated as Python 3.9](https://docs.python.org/3/library/typing.html#typing.List), but I see that the older annotations are still in use here.~~
>
> Looks like `typing.List` is still required.