### PR TITLE
WIP Small tweaks in the prepare stages

### DIFF
--- a/interfaces/__template__/v0/interface.yaml
+++ b/interfaces/__template__/v0/interface.yaml
@@ -27,7 +27,7 @@ status: draft
 providers:
   - name: charm-using-the-provider-side
     url: https://github.com/foo/charm-using-the-provider-side-k8s-operator  # repo to clone for the tests; required
-    test_setup: # optional
+    test_setup:  # optional
       charm_root: relative/path  # if the charm isn't at the root of the repo
       identifier: tracing_tester  # custom identifier for the InterfaceTester-yielding fixture...
       location: tests/interface/conftest.py  # ...and where to find it


### PR DESCRIPTION
* I feel like subprocess.run would be a simpler choice than using Popen directly - and also it seems very unlikely that there could be any other error than the process failing (although I should check if the timeout raises CalledProcessError or something else) - also fixes what is I think a bug where `{error}` should be `{e}` and there's an unnecessary `str()`
* 