### PR TITLE
update tempo-cluster schema

### DIFF
--- a/docs/json_schemas/tempo_cluster/v1/provider.json
+++ b/docs/json_schemas/tempo_cluster/v1/provider.json
@@ -71,6 +71,23 @@
           "description": "Server certificate for tls encryption.",
           "title": "Server Cert"
         },
+        "s3_tls_ca_cert": {
+          "anyOf": [
+            {
+              "contentMediaType": "application/json",
+              "contentSchema": {
+                "type": "string"
+              },
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "CA certificate for the s3 bucket API.",
+          "title": "S3 Tls Ca Cert"
+        },
         "privkey_secret_id": {
           "anyOf": [
             {
@@ -150,6 +167,26 @@
           "default": null,
           "description": "Endpoints to which the worker node can push its workload traces to.It is a mapping from protocol names such as `zipkin`, `otlp_grpc`, `otlp_http`.",
           "title": "Workload Tracing Receivers"
+        },
+        "worker_ports": {
+          "anyOf": [
+            {
+              "contentMediaType": "application/json",
+              "contentSchema": {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ports that the worker should open on its pod.",
+          "title": "Worker Ports"
         }
       },
       "required": [

--- a/interfaces/tempo_cluster/v1/README.md
+++ b/interfaces/tempo_cluster/v1/README.md
@@ -8,7 +8,7 @@ The coordinator will use the same relation to convey to the workers back the con
 
 ## Direction
 
-This interface implements a provider/requirer pattern. The coordinator charm is the provider of the relation, the worker charm is the requirer. Information flows back and forth: first the requirer shares some data necessary for the coordinator to know the role of the worker, then the provider replies back with the configuration it should run with. 
+This interface implements a provider/requirer pattern. The coordinator charm is the provider of the relation, the worker charm is the requirer. Information flows back and forth: first the requirer shares some data necessary for the coordinator to know the role of the worker, then the provider replies back with the configuration it should run with and other bits of configuration for the charm to use. 
 
 ```mermaid
 flowchart TD
@@ -22,12 +22,13 @@ flowchart TD
 The provider is expected to...
 - update the gossip rings in all configurations with the addresses of all worker units that are joining the cluster (regardless of their role).
 - share the exact same configuration to all nodes, regardless of the role they declare, via application databag.
+- share all other data required by the schema.
 
 ### Requirer
 The requirer application is expected to...
 - publish its role as soon as possible via application databag.  
 Each requirer unit is expected to...
-- publish its address and JujuTopology as soon as possible, via unit databag.
+- publish its address (fqdn) and JujuTopology as soon as possible, via unit databag.
 
 ## Relation Data
 
@@ -38,7 +39,7 @@ Each requirer unit is expected to...
 provider:
   app: 
     worker_config: 
-      # <a very large chunk of yaml, conforming to Tempo configuration specification: https://grafana.com/docs/tempo/latest/configuration/#configure-tempo>
+      # <a chunk of yaml, conforming to Tempo configuration specification: https://grafana.com/docs/tempo/latest/configuration/#configure-tempo>
   unit: {}
   
 requirer:
@@ -46,9 +47,10 @@ requirer:
     role: receiver
   unit: 
    juju_topology: 
-     model: "mymodel", 
-     model_uuid: "1231234120941234", 
-     application: "tempo-receiver", 
-     charm_name: "tempo-worker-k8s", 
-     unit: "tempo-receiver/2", 
+     model: "mymodel"
+     model_uuid: "1231234120941234"
+     application: "tempo-receiver"
+     charm_name: "tempo-worker-k8s"
+     unit: "tempo-receiver/2"
+  address: "foo-model0.cluster.local" # fqdn
 ```

--- a/interfaces/tempo_cluster/v1/schema.py
+++ b/interfaces/tempo_cluster/v1/schema.py
@@ -31,6 +31,9 @@ class TempoClusterProviderAppData(BaseModel):
     server_cert: Optional[Json[str]] = Field(
         default=None, description="Server certificate for tls encryption."
     )
+    s3_tls_ca_cert: Optional[Json[str]] = Field(
+        default=None, description="CA certificate for the s3 bucket API."
+    )
     privkey_secret_id: Optional[Json[str]] = Field(
         default=None,
         description="ID of a Juju secret that holds the private key used by the coordinator for TLS encryption.",
@@ -48,6 +51,10 @@ class TempoClusterProviderAppData(BaseModel):
         default=None,
         description="Endpoints to which the worker node can push its workload traces to."
         "It is a mapping from protocol names such as `zipkin`, `otlp_grpc`, `otlp_http`.",
+    )
+    worker_ports: Optional[Json[List[int]]] = Field(
+        default=None,
+        description="Ports that the worker should open on its pod.",
     )
 
 


### PR DESCRIPTION
the tempo-cluster schema [is gaining a new field](https://github.com/canonical/cos-lib/pull/131): the worker_ports field.
Updated the schema to reflect that.