### PR TITLE
feat: Creates V1 of the fiveg_rfsim interface

### DIFF
--- a/docs/json_schemas/fiveg_rfsim/v1/provider.json
+++ b/docs/json_schemas/fiveg_rfsim/v1/provider.json
@@ -1,0 +1,131 @@
+{
+  "$defs": {
+    "BaseModel": {
+      "properties": {},
+      "title": "BaseModel",
+      "type": "object"
+    },
+    "FivegRFSIMProviderAppData": {
+      "properties": {
+        "rfsim_address": {
+          "description": "RF simulator service ip",
+          "examples": [
+            "192.168.70.130"
+          ],
+          "title": "Rfsim Address",
+          "type": "string"
+        },
+        "sst": {
+          "description": "Slice/Service Type",
+          "examples": [
+            1,
+            2,
+            3,
+            4
+          ],
+          "maximum": 255,
+          "minimum": 0,
+          "title": "Sst",
+          "type": "integer"
+        },
+        "sd": {
+          "anyOf": [
+            {
+              "maximum": 16777215,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Slice Differentiator",
+          "examples": [
+            1
+          ],
+          "title": "Sd"
+        },
+        "band": {
+          "default": null,
+          "description": "Frequency band",
+          "examples": [
+            34,
+            77,
+            102
+          ],
+          "title": "Band",
+          "type": "integer"
+        },
+        "dl_freq": {
+          "default": null,
+          "description": "Downlink frequency in Hz",
+          "examples": [
+            4059090000
+          ],
+          "title": "Dl Freq",
+          "type": "integer"
+        },
+        "carrier_bandwidth": {
+          "default": null,
+          "description": "Carrier bandwidth (number of downlink PRBs)",
+          "examples": [
+            106
+          ],
+          "title": "Carrier Bandwidth",
+          "type": "integer"
+        },
+        "numerology": {
+          "default": null,
+          "description": "Numerology",
+          "examples": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "title": "Numerology",
+          "type": "integer"
+        },
+        "start_subcarrier": {
+          "default": null,
+          "description": "First usable subcarrier",
+          "examples": [
+            530,
+            541
+          ],
+          "title": "Start Subcarrier",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "rfsim_address",
+        "sst"
+      ],
+      "title": "FivegRFSIMProviderAppData",
+      "type": "object"
+    }
+  },
+  "description": "Provider schema for the fiveg_rfsim interface.",
+  "properties": {
+    "unit": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BaseModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "app": {
+      "$ref": "#/$defs/FivegRFSIMProviderAppData"
+    }
+  },
+  "required": [
+    "app"
+  ],
+  "title": "ProviderSchema",
+  "type": "object"
+}

--- a/docs/json_schemas/fiveg_rfsim/v1/requirer.json
+++ b/docs/json_schemas/fiveg_rfsim/v1/requirer.json
@@ -1,0 +1,36 @@
+{
+  "$defs": {
+    "BaseModel": {
+      "properties": {},
+      "title": "BaseModel",
+      "type": "object"
+    }
+  },
+  "description": "Requirer schema for the fiveg_rfsim interface.",
+  "properties": {
+    "unit": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BaseModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "app": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BaseModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    }
+  },
+  "title": "RequirerSchema",
+  "type": "object"
+}

--- a/interfaces/fiveg_rfsim/v1/README.md
+++ b/interfaces/fiveg_rfsim/v1/README.md
@@ -1,0 +1,63 @@
+# `fiveg_rfsim`
+
+## Usage
+
+Within 5G RAN (Radio Access Network) architecture, the OAI DU charm can be started to act as both the DU and the RU through its RF simulator functionality. 
+
+The OAI UE charm requires RF simulator address and the network information(SST, SD) in order to connect. Hence, the provider of this interface would be a OAI DU charm and the requirer of this interface would be the OAI UE charm.
+
+This relation interface describes the expected behavior of charms claiming to be able to provide or consume information on connectivity over the fiveg_rfsim interface.
+
+## Direction
+
+```mermaid
+flowchart TD
+    Provider -- rfsim_address, sst, sd --> Requirer
+```
+
+As with all Juju relations, the `fiveg_rfsim` interface consists of two parties: a Provider and a Requirer.
+
+## Behavior
+
+Both the Requirer and the Provider need to adhere to criteria to be considered compatible with the interface.
+
+### Provider
+
+Is expected to provide following information:
+
+- The DU's `rfsim` service ip
+- Network Slice/Service Type (SST)
+- Slice Differentiator (SD)
+- Frequency band
+- Downlink frequency (in Hz)
+- Carrier bandwidth (number of downlink PRBs)
+- Numerology
+- Start subcarrier
+
+### Requirer
+
+- Is expected to use the `rfsim` service address and the network information(SST, SD) passed by the provider.
+
+## Relation Data
+
+[\[Pydantic Schema\]](./schema.py)
+
+#### Example
+
+```yaml
+provider:
+  app: {
+    "rfsim_address": "192.168.70.130",
+    "sst": 1,
+    "sd": 1,
+    "band": 77,
+    "dl_freq": 4059090000,
+    "carrier_bandwidth": 106,
+    "numerology": 1,
+    "start_subcarrier": 541,
+  }
+  unit: {}
+requirer:
+  app: {}
+  unit: {}
+```

--- a/interfaces/fiveg_rfsim/v1/interface.yaml
+++ b/interfaces/fiveg_rfsim/v1/interface.yaml
@@ -1,0 +1,14 @@
+name: fiveg_rfsim
+internal: true
+version: 1
+status: draft
+
+providers:
+  - name: oai-ran-du-k8s
+    url: https://github.com/canonical/oai-ran-du-k8s-operator
+
+requirers:
+  - name: oai-ran-ue-k8s
+    url: https://github.com/canonical/oai-ran-ue-k8s-operator
+
+maintainer: telco

--- a/interfaces/fiveg_rfsim/v1/schema.py
+++ b/interfaces/fiveg_rfsim/v1/schema.py
@@ -1,0 +1,80 @@
+"""This file defines the schemas for the provider and requirer sides of the `fiveg_rfsim` interface.
+It exposes two interface_tester.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {
+            "rfsim_address": "192.168.70.130",
+            "sst": 1,
+            "sd": 1,
+            "band": 77,
+            "dl_freq": 4059090000,
+            "carrier_bandwidth": 106,
+            "numerology": 1,
+            "start_subcarrier": 541,
+        }
+    RequirerSchema:
+        unit: <empty>
+        app:  <empty>
+"""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from interface_tester.schema_base import DataBagSchema
+
+
+class FivegRFSIMProviderAppData(BaseModel):
+    rfsim_address: str = Field(
+        description="RF simulator service ip",
+        examples=["192.168.70.130"]
+    )
+    sst: int = Field(
+        description="Slice/Service Type",
+        examples=[1, 2, 3, 4],
+        ge=0,
+        le=255,
+    )
+    sd: Optional[int] = Field(
+        description="Slice Differentiator",
+        default=None,
+        examples=[1],
+        ge=0,
+        le=16777215,
+    )
+    band: int = Field(
+        description="Frequency band",
+        default=None,
+        examples=[34, 77, 102],
+    )
+    dl_freq: int = Field(
+        description="Downlink frequency in Hz",
+        default=None,
+        examples=[4059090000],
+    )
+    carrier_bandwidth: int = Field(
+        description="Carrier bandwidth (number of downlink PRBs)",
+        default=None,
+        examples=[106],
+    )
+    numerology: int = Field(
+        description="Numerology",
+        default=None,
+        examples=[0, 1, 2, 3],
+    )
+    start_subcarrier: int = Field(
+        description="First usable subcarrier",
+        default=None,
+        examples=[530, 541],
+    )
+
+
+class ProviderSchema(DataBagSchema):
+    """Provider schema for the fiveg_rfsim interface."""
+    app: FivegRFSIMProviderAppData
+
+
+class RequirerSchema(DataBagSchema):
+    """Requirer schema for the fiveg_rfsim interface."""


### PR DESCRIPTION
This PR creates a new version of the `fiveg_rfsim` interface. 
New interface will allow for dynamic configuration of the UE simulator startup parameters, which will now be sent by the DU. This will ensure configuration consistency and allow for testing the 5G network using different RF configs.