### PR TITLE
[DPE-6555] Add URIs and read only URIs to Postgresql and Mysql

### DIFF
--- a/interfaces/mysql_client/v0/README.md
+++ b/interfaces/mysql_client/v0/README.md
@@ -30,6 +30,8 @@ If any side, Provider or Requirer doesn't support Juju Secrets, sensitive inform
 - Is expected to expose the Juju Secrets URI to the credentials through the `secret-user` field of the data bag.
 - Is expected to provide the `endpoints` field with the address of Primary, which can be used for Read/Write queries.
 - Is expected to provide the `database` field with the database that was actually created.
+- Is expected to provide the `uris` field with the connection string, in mysqlshell's URI format, which can be used for direct connection to the db.
+- Is expected to provide the `read-only-uris` field with the connection string when requested as a secret field, in mysqlshell's URI format, which can be used for direct connection to a read only edpoint of a cluster.
 - Is expected to provide optional `read-only-endpoints` field with a comma-separated list of hosts or one Kubernetes Service, which can be used for Read-only queries.
 - Is expected to provide the `version` field whenever database charm wants to communicate its database version.
 - Is expected to provide the CA chain in the `tls-ca` field of a Juju Secret, whenever the provider has TLS enabled (such as using the [TLS Certificates Operator](https://github.com/canonical/tls-certificates-operator)).

--- a/interfaces/mysql_client/v0/schemas/provider.json
+++ b/interfaces/mysql_client/v0/schemas/provider.json
@@ -53,6 +53,16 @@
                 "unit-1:port,unit-2:port"
             ]
         },
+        "uris": {
+            "$id": "#/properties/uris",
+            "title": "URIs",
+            "description": "A connection string in URI format used to connect to the database",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "mysql://user:pass@host:port/mydb"
+            ]
+        },
         "read-only-endpoints": {
             "$id": "#/properties/read-only-endpoints",
             "title": "Read-Only Database Endpoints",
@@ -61,6 +71,16 @@
             "default": "",
             "examples": [
                 "unit-1:port,unit-2:port"
+            ]
+        },
+        "read-only-uris": {
+            "$id": "#/properties/read-only-uris",
+            "title": "Read only URIs",
+            "description": "A connection string in URI format used to connect to the read only endpoint of the database",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "mysql://user:pass@host:port/mydb"
             ]
         },
         "version": {

--- a/interfaces/postgresql_client/v0/README.md
+++ b/interfaces/postgresql_client/v0/README.md
@@ -33,6 +33,7 @@ If any side, Provider or Requirer doesn't support Juju Secrets, sensitive inform
 - Is expected to provide the `endpoints` field with the address of Primary, which can be used for Read/Write queries.
 - Is expected to provide the `database` field with the database that was actually created.
 - Is expected to provide the `uris` field with the connection string, in libpq's URI format, which can be used for direct connection to the db.
+- Is expected to provide the `read-only-uris` field with the connection string when requested as a secret field, in libpq's URI format, which can be used for direct connection to a read only edpoint of a cluster.
 - Is expected to provide optional `read-only-endpoints` field with a comma-separated list of hosts or one Kubernetes Service, which can be used for Read-only queries.
 - Is expected to provide the `version` field whenever database charm wants to communicate its database version.
 - Is expected to provide the `tls` field flag, indicating whether the provider has TLS enabled or not.

--- a/interfaces/postgresql_client/v0/schemas/provider.json
+++ b/interfaces/postgresql_client/v0/schemas/provider.json
@@ -73,6 +73,16 @@
                 "unit-1:port,unit-2:port"
             ]
         },
+        "read-only-uris": {
+            "$id": "#/properties/read-only-uris",
+            "title": "Read only URIs",
+            "description": "A connection string in URI format used to connect to the read only endpoint of the database",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "postgresql://user:pass@host-1:port,host-2:port/mydb"
+            ]
+        },
         "version": {
             "$id": "#/properties/version",
             "title": "Version",


### PR DESCRIPTION
Specification: DA158
Charm lib PR: https://github.com/canonical/data-platform-libs/pull/206

Adds URIs field to Mysql interface and read only URIs to Postgresql interface