### PR TITLE
chore: improve fiveg_core_gnb interface schema

### DIFF
--- a/docs/json_schemas/fiveg_core_gnb/v0/requirer.json
+++ b/docs/json_schemas/fiveg_core_gnb/v0/requirer.json
@@ -12,6 +12,7 @@
           "examples": [
             "gnb001"
           ],
+          "pattern": "^[a-zA-Z][a-zA-Z0-9-_]{1,255}$",
           "title": "Gnb-Name",
           "type": "string"
         }

--- a/interfaces/fiveg_core_gnb/v0/schema.py
+++ b/interfaces/fiveg_core_gnb/v0/schema.py
@@ -74,7 +74,8 @@ class FivegCoreGnbRequirerAppData(BaseModel):
     gnb_name: str = Field(
         alias="gnb-name",
         description="Unique identifier of the CU/gnB.",
-        examples=["gnb001"]
+        examples=["gnb001"],
+        pattern="^[a-zA-Z][a-zA-Z0-9-_]{1,255}$",
     )
 
 


### PR DESCRIPTION
This PR aims to improve the schema of the `fiveg_core_gnb` interface.
In particular it adds regular expression validation for the `gnb-name` parameter:
* only alphanumeric, underscores, dashes are allowed
* name must be between 2 and 256 characters, with the first one being alphabetic.