### PR TITLE
Update etcd client interface

### DIFF
--- a/docs/json_schemas/etcd_client/v0/provider.json
+++ b/docs/json_schemas/etcd_client/v0/provider.json
@@ -33,7 +33,7 @@
     "endpoints": {
       "description": "Comma separated list of etcd endpoints",
       "examples": [
-        "http://etcd1:2379,http://etcd2:2379"
+        "etcd1:2379,etcd2:2379"
       ],
       "title": "etcd Endpoints",
       "type": "string"

--- a/docs/json_schemas/etcd_client/v0/requirer.json
+++ b/docs/json_schemas/etcd_client/v0/requirer.json
@@ -47,8 +47,8 @@
       "type": "string"
     },
     "requested_secrets": {
-      "description": "The fields required to be a secret. Needs to contain 'username' and 'tls-ca'",
-      "examples": "[\"username\", \"tls-ca\"]",
+      "description": "The fields required to be a secret.",
+      "examples": "[\"username\", \"uris\", \"tls\", \"tls-ca\"]",
       "title": "Requested Secrets",
       "type": "string"
     },

--- a/interfaces/etcd_client/v0/interface_tests/test_provider.py
+++ b/interfaces/etcd_client/v0/interface_tests/test_provider.py
@@ -37,7 +37,7 @@ def test_add_provider_content():
                     remote_app_data={
                         "prefix": "/my/keys",
                         "secret-mtls": secret.id,
-                        "requested-secrets": ["username", "tls-ca"],
+                        "requested-secrets": ["username", "uris", "tls", "tls-ca"],
                         "provided-secrets": ["mtls-cert"],
                     },
                 )

--- a/interfaces/etcd_client/v0/schema.py
+++ b/interfaces/etcd_client/v0/schema.py
@@ -8,11 +8,10 @@ from pydantic import Field
 class ProviderSchema(DataBagSchema):
     """The schema for the provider side of this interface."""
 
-    # comma separated list of etcd endpoints
     endpoints: str = Field(
         description="Comma separated list of etcd endpoints",
         title="etcd Endpoints",
-        examples=["http://etcd1:2379,http://etcd2:2379"],
+        examples=["etcd1:2379,etcd2:2379"],
     )
 
     version: str = Field(
@@ -50,9 +49,9 @@ class RequirerSchema(DataBagSchema):
     )
 
     requested_secrets: str = Field(
-        description="The fields required to be a secret. Needs to contain 'username' and 'tls-ca'",
+        description="The fields required to be a secret.",
         title="Requested Secrets",
-        examples='["username", "tls-ca"]',
+        examples='["username", "uris", "tls", "tls-ca"]',
     )
 
     provided_secrets: str = Field(


### PR DESCRIPTION

### Updates to JSON Schemas:

* [`docs/json_schemas/etcd_client/v0/provider.json`](diffhunk://#diff-8d5e8d381050d692bea837f97d41dbc9f508b636ff3ff5e8814fb9436c94665cL36-R36): Updated the example for `endpoints` to remove the protocol prefix.
* [`docs/json_schemas/etcd_client/v0/requirer.json`](diffhunk://#diff-528375a881aaa038937eb20fb9538cbc76daf7c63e381a2a135f5185191eede8L50-R51): Expanded the `requested_secrets` example to include additional fields.

### Documentation Improvements:

* [`interfaces/etcd_client/v0/README.md`](diffhunk://#diff-80ceedc75627d6862a812581be0880612cd45d932619ca18d273a54ee6d76591L32-R51): Enhanced the documentation to clarify the expected fields for both the Provider and Requirer, including new fields for Juju Secrets and updated descriptions for existing fields. [[1]](diffhunk://#diff-80ceedc75627d6862a812581be0880612cd45d932619ca18d273a54ee6d76591L32-R51) [[2]](diffhunk://#diff-80ceedc75627d6862a812581be0880612cd45d932619ca18d273a54ee6d76591L67-R77)

### Test Case Updates:

* [`interfaces/etcd_client/v0/interface_tests/test_provider.py`](diffhunk://#diff-d753e077fdc62ae8d129a889e42d19ad668916485230c13579f4608bb59f0c34L40-R40): Modified the test case to include the new `requested-secrets` fields.

### Schema Adjustments:

* [`interfaces/etcd_client/v0/schema.py`](diffhunk://#diff-67db9064d66515955ef216beb539060fca4daf0fa3df59b278cf593754c110eaL11-R14): Updated the `ProviderSchema` and `RequirerSchema` to reflect the new examples and descriptions for `endpoints` and `requested_secrets`. [[1]](diffhunk://#diff-67db9064d66515955ef216beb539060fca4daf0fa3df59b278cf593754c110eaL11-R14) [[2]](diffhunk://#diff-67db9064d66515955ef216beb539060fca4daf0fa3df59b278cf593754c110eaL53-R54)