### PR TITLE
Update Data Platform interfaces

### DIFF
--- a/interfaces/kafka_client/v0/README.md
+++ b/interfaces/kafka_client/v0/README.md
@@ -23,15 +23,20 @@ Both the Requirer and the Provider need to adhere to the criteria, to be conside
 ### Provider
 - Is expected to create an application `username` and `password` inside the kafka cluster when the requirer relates to the kafka cluster, using the SASL/SCRAM mechanism, stored in ZooKeeper.
 - Is expected to delete an application `username` and `password` from the kafka cluster when the relation is removed.
+- Is expected to provide a custom entity `entity-name` and `entity-password` inside the kafka cluster when the requirer relates to the kafka cluster when the `entity-type` field is supplied.
+- Is expected to delete a custom entity `entity-name` and `entity-password` from the kafka cluster when the relation is removed.
 - Is expected to provide the `endpoints` field with a comma-seperated list of broker hostnames / IP addresses.
 - Is expected to provide the `topic` field with the topic that was actually created.
 - Can optionally provide the `consumer-group-prefix` field with the prefixed consumer groups, if requirer `extra-user-roles` is includes `consumer`
 - Can optionally provide the `zookeeper-uris` field with a comma-seperated list of ZooKeeper server uris and Kafka cluster zNode, if the requirer `extra-user-roles` includes `admin`
 
 ### Requirer
-- Is expected to provide the `extra-user-roles` field specifying a comma-separated list of roles for the client application (between `admin`, `consumer` and `producer`).
 - Can optionally provide the `topic` field specifying the topic that the requirer charm needs permissions to create (for `extra-user-roles=producer`), or consume (for `extra-user-roles=consumer`).
 - Is expected to tolerate that the Provider may ignore the `topic` field in some cases and instead use the topic name received.
+- Is expected to provide the `extra-user-roles` field specifying a comma-separated list of roles for the requested user or client application (between `admin`, `consumer` and `producer`).
+- Can optionally provide the `extra-group-roles` field specifying a comma-separated list of roles for the requested group (e.g. `extra-group-roles=admin`).
+- Can optionally provide the `entity-type` field specifying the type of entity to request, instead of a topic.
+- Can optionally provide the `entity-permissions` field specifying the permissions for the requested entity.
 - Can optionally provide the `consumer-group-prefix` field specifying the consumer-group-prefix that the requirer charm needs permissions to consume (for `extra-user-roles=consumer`).
 
 ## Relation Data

--- a/interfaces/kafka_client/v0/schemas/provider.json
+++ b/interfaces/kafka_client/v0/schemas/provider.json
@@ -59,6 +59,26 @@
          "examples":[
             "10.141.78.155:2181,10.141.78.62:2181,10.141.78.186:2181/kafka"
          ]
+      },
+      "entity-name": {
+         "$id": "#/properties/username",
+         "title": "Entity name",
+         "description": "Name for the requested custom entity.",
+         "type": "string",
+         "default": "",
+         "examples": [
+            "custom-role"
+         ]
+      },
+      "entity-password": {
+         "$id": "#/properties/password",
+         "title": "Entity password",
+         "description": "Password for the requested custom entity.",
+         "type": "string",
+         "default": "",
+         "examples": [
+            "alphanum-32byte-random"
+         ]
       }
    },
    "examples":[

--- a/interfaces/kafka_client/v0/schemas/requirer.json
+++ b/interfaces/kafka_client/v0/schemas/requirer.json
@@ -1,47 +1,64 @@
 {
-   "$schema":"https://json-schema.org/draft/2019-09/schema",
-   "$id":"https://canonical.github.io/charm-relation-interfaces/interfaces/kafka_client/schemas/requirer.json",
-   "title":"`kafka` requirer schema",
-   "description":"The `kafka_client` root schema comprises the entire requirer databag for this interface.",
-   "type":"object",
-   "default":{
-      
-   },
-   "required":[
+   "$schema": "https://json-schema.org/draft/2019-09/schema",
+   "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/kafka_client/schemas/requirer.json",
+   "title": "`kafka` requirer schema",
+   "description": "The `kafka_client` root schema comprises the entire requirer databag for this interface.",
+   "type": "object",
+   "default": {},
+   "required": [
       "extra-user-roles"
    ],
-   "if":{
-      "properties":{
-         "extra-user-roles":{
-            "pattern":"producer"
+   "if": {
+      "properties": {
+         "extra-user-roles": {
+            "pattern": "producer"
          }
       }
    },
-   "then":{
-      "required":[
+   "then": {
+      "required": [
          "topic"
       ]
    },
-   "if":{
-      "properties":{
-         "extra-user-roles":{
-            "pattern":"consumer"
+   "if": {
+      "properties": {
+         "extra-user-roles": {
+            "pattern": "consumer"
          }
       }
    },
-   "then":{
-      "required":[
+   "then": {
+      "required": [
          "topic"
       ]
    },
-   "additionalProperties":true,
-   "properties":{
+   "additionalProperties": true,
+   "properties": {
+      "topic": {
+         "title": "Kafka topic name",
+         "description": "The topic name access requested by the requirer",
+         "type": "string",
+         "default": "",
+         "examples": [
+            "topic-1",
+            "appname-*"
+         ]
+      },
+      "consumer-group-prefix": {
+         "title": "Kafka consumer group prefix",
+         "description": "A prefix for wildcard consumer-group ids that have been granted permissions",
+         "type": "string",
+         "default": "",
+         "examples": [
+            "relation-14-"
+         ]
+      },
       "extra-user-roles":{
-         "title":"Application client roles",
-         "description":"A comma-seperated list of application roles requested by the requirer",
-         "type":"string",
-         "default":"",
-         "enum":[
+         "title": "Application client roles",
+         "description": "A comma-seperated list of application roles requested by the requirer",
+         "type": "string",
+         "default": "",
+         "enum": [
             "consumer",
             "producer",
             "admin",
@@ -50,7 +67,7 @@
             "producer,admin",
             "consumer,producer,admin"
          ],
-         "examples":[
+         "examples": [
             "consumer",
             "producer",
             "admin",
@@ -60,31 +77,40 @@
             "consumer,producer,admin"
          ]
       },
-      "topic":{
-         "title":"Kafka topic name",
-         "description":"The topic name access requested by the requirer",
-         "type":"string",
-         "default":"",
-         "examples":[
-            "topic-1",
-            "appname-*"
+      "extra-group-roles": {
+         "title": "Extra-group-roles",
+         "description": "Any extra group roles requested by the requirer",
+         "type": "string",
+         "default": "",
+         "examples": [
+            "charmed_read,charmed_dml"
          ]
       },
-      "consumer-group-prefix":{
-         "title":"Kafka consumer group prefix",
-         "description":"A prefix for wildcard consumer-group ids that have been granted permissions",
-         "type":"string",
-         "default":"",
-         "examples":[
-            "relation-14-"
+      "entity-type": {
+         "title": "Entity-type",
+         "description": "Type of the requested entity (user / group)",
+         "type": "string",
+         "default": "",
+         "examples": [
+            "USER",
+            "GROUP"
+         ]
+      },
+      "entity-permissions": {
+         "title": "Entity-permissions",
+         "description": "List of permissions to assigned to the custom entity, in JSON format",
+         "type": "string",
+         "default": "",
+         "examples": [
+            "[{\"resource_name\": \"messages\", \"resource_type\": \"TOPIC\", \"privileges\": [\"READ\"]}]"
          ]
       }
    },
    "examples":[
       {
-         "extra-user-roles":"consumer",
          "topic":"special-topic",
-         "consumer-group-prefix": "my-consumer-group"
+         "consumer-group-prefix": "my-consumer-group",
+         "extra-user-roles":"consumer"
       }
    ]
 }

--- a/interfaces/mongodb_client/v0/README.md
+++ b/interfaces/mongodb_client/v0/README.md
@@ -26,7 +26,8 @@ If any side, Provider or Requirer doesn't support Juju Secrets, sensitive inform
 
 ### Provider
 - Is expected to create an application user inside the database cluster when the requirer provides the `database` field.
-- Is expected to provide credentials (`username` and `password`) in a Juju Secret whenever the Requirer supplies the `database` field.
+- Is expected to provide relation user credentials (`username` and `password`) in a Juju Secret whenever the Requirer supplies the `database` field, but not the `entity-type` one.
+- Is expected to provide custom entity credentials (`entity-name` and `entity-password`) in a Juju Secret whenever the Requirer supplies both the `database` and `entity-type` fields.
 - Is expected to expose the Juju Secrets URI to the credentials through the `secret-user` field of the data bag.
 - Is expected to provide the `endpoints` field with a comma-separated list of hosts, which can be used for database connection.
 - Is expected to provide the `database` field with the database that was actually created.
@@ -44,7 +45,10 @@ If any side, Provider or Requirer doesn't support Juju Secrets, sensitive inform
 - Is expected to have unique credentials for each relation. Therefore, different instances of the same Charm (juju applications) will have different relations with different credentials.
 - Is expected to have different relations names on Requirer with the same interface name if Requirer needs access to multiple database charms.
 - Is expected to allow multiple different Juju applications to access the same database name.
-- Is expected to add any `extra-user-roles` provided by the Requirer to the created user (e.g. `extra-user-roles=admin`).
+- Can optionally add any `extra-user-roles` provided by the Requirer to the requested user or relation user (e.g. `extra-user-roles=admin`).
+- Can optionally add any `extra-group-roles` provided by the Requirer to the requested group (e.g. `extra-group-roles=admin`).
+- Can optionally add field `entity-type` provided by the Requirer to the created a custom entity, instead of a database.
+- Can optionally add field `entity-permissions` provided by the Requirer to tweak custom entity permissions.
 - Is expected to tolerate that the Provider may ignore the `database` field in some cases and instead use the database name received.
 
 ## Relation Data

--- a/interfaces/mongodb_client/v0/schemas/provider.json
+++ b/interfaces/mongodb_client/v0/schemas/provider.json
@@ -82,6 +82,26 @@
             "examples": [
                 "8.0.27-18"
             ]
+        },
+        "entity-name": {
+            "$id": "#/properties/username",
+            "title": "Entity name",
+            "description": "Name for the requested custom entity.",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "custom-role"
+            ]
+        },
+        "entity-password": {
+            "$id": "#/properties/password",
+            "title": "Entity password",
+            "description": "Password for the requested custom entity.",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "alphanum-32byte-random"
+            ]
         }
     },
     "examples": [{

--- a/interfaces/mongodb_client/v0/schemas/requirer.json
+++ b/interfaces/mongodb_client/v0/schemas/requirer.json
@@ -35,6 +35,34 @@
             "examples": [
                 "default,admin"
             ]
+        },
+        "extra-group-roles": {
+            "title": "Extra-group-roles",
+            "description": "Any extra group roles requested by the requirer",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "charmed_read,charmed_dml"
+            ]
+        },
+        "entity-type": {
+            "title": "Entity-type",
+            "description": "Type of the requested entity (user / group)",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "USER",
+                "GROUP"
+            ]
+        },
+        "entity-permissions": {
+            "title": "Entity-permissions",
+            "description": "List of permissions to assigned to the custom entity, in JSON format",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "[{\"resource_name\": \"myapp\", \"resource_type\": \"DATABASE\", \"privileges\": [\"READ\"]}]"
+            ]
         }
     },
     "examples": [{

--- a/interfaces/mysql_client/v0/README.md
+++ b/interfaces/mysql_client/v0/README.md
@@ -26,7 +26,8 @@ If any side, Provider or Requirer doesn't support Juju Secrets, sensitive inform
 
 ### Provider
 - Is expected to create an application user inside the database cluster when the requirer provides the `database` field.
-- Is expected to provide credentials (`username` and `password`) in a Juju Secret whenever the Requirer supplies the `database` field.
+- Is expected to provide relation user credentials (`username` and `password`) in a Juju Secret whenever the Requirer supplies the `database` field, but not the `entity-type` one.
+- Is expected to provide custom entity credentials (`entity-name` and `entity-password`) in a Juju Secret whenever the Requirer supplies both the `database` and `entity-type` fields.
 - Is expected to expose the Juju Secrets URI to the credentials through the `secret-user` field of the data bag.
 - Is expected to provide the `endpoints` field with the address of Primary, which can be used for Read/Write queries.
 - Is expected to provide the `database` field with the database that was actually created.
@@ -45,7 +46,10 @@ If any side, Provider or Requirer doesn't support Juju Secrets, sensitive inform
 - Is expected to have unique credentials for each relation. Therefore, different instances of the same Charm (juju applications) will have different relations with different credentials.
 - Is expected to have different relations names on Requirer with the same interface name if Requirer needs access to multiple database charms.
 - Is expected to allow multiple different Juju applications to access the same database name.
-- Is expected to add any `extra-user-roles` provided by the Requirer to the created user (e.g. `extra-user-roles=admin`).
+- Can optionally add any `extra-user-roles` provided by the Requirer to the requested user or relation user (e.g. `extra-user-roles=admin`).
+- Can optionally add any `extra-group-roles` provided by the Requirer to the requested group (e.g. `extra-group-roles=admin`).
+- Can optionally add field `entity-type` provided by the Requirer to the created a custom entity, instead of a database.
+- Can optionally add field `entity-permissions` provided by the Requirer to tweak custom entity permissions.
 - Is expected to tolerate that the Provider may ignore the `database` field in some cases and instead use the database name received.
 
 ## Relation Data

--- a/interfaces/mysql_client/v0/schemas/provider.json
+++ b/interfaces/mysql_client/v0/schemas/provider.json
@@ -92,6 +92,26 @@
             "examples": [
                 "8.0.27-18"
             ]
+        },
+        "entity-name": {
+            "$id": "#/properties/username",
+            "title": "Entity name",
+            "description": "Name for the requested custom entity.",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "custom-role"
+            ]
+        },
+        "entity-password": {
+            "$id": "#/properties/password",
+            "title": "Entity password",
+            "description": "Password for the requested custom entity.",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "alphanum-32byte-random"
+            ]
         }
     },
     "examples": [{

--- a/interfaces/mysql_client/v0/schemas/requirer.json
+++ b/interfaces/mysql_client/v0/schemas/requirer.json
@@ -35,6 +35,34 @@
             "examples": [
                 "default,admin"
             ]
+        },
+        "extra-group-roles": {
+            "title": "Extra-group-roles",
+            "description": "Any extra group roles requested by the requirer",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "charmed_read,charmed_dml"
+            ]
+        },
+        "entity-type": {
+            "title": "Entity-type",
+            "description": "Type of the requested entity (user / group)",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "USER",
+                "GROUP"
+            ]
+        },
+        "entity-permissions": {
+            "title": "Entity-permissions",
+            "description": "List of permissions to assigned to the custom entity, in JSON format",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "[{\"resource_name\": \"items\", \"resource_type\": \"TABLE\", \"privileges\": [\"SELECT\"]}]"
+            ]
         }
     },
     "examples": [{

--- a/interfaces/opensearch_client/v0/README.md
+++ b/interfaces/opensearch_client/v0/README.md
@@ -32,7 +32,8 @@ If any side, Provider or Requirer doesn't support Juju Secrets, sensitive inform
 - Is not expected to create an index on relation creation.
   - Responsibility for managing an index rests with the requirer application, including creating and removing indices.
 - Is expected to provide the `index` field with the index that has been made available to the Requirer.
-- Is expected to provide credentials (`username` and `password`) in a Juju Secret whenever the Requirer supplies the `index` field.
+- Is expected to provide relation user credentials (`username` and `password`) in a Juju Secret whenever the Requirer supplies the `index` field, but not the `entity-type` one.
+- Is expected to provide custom entity credentials (`entity-name` and `entity-password`) in a Juju Secret whenever the Requirer supplies both the `index` and `entity-type` fields.
 - Is expected to expose the Juju Secrets URI to the credentials through the `secret-user` field of the data bag.
 - Is expected to provide the `endpoints` field containing all cluster endpoint addresses in a comma-separated list.
 - Is expected to provide the `version` field describing the installed version number of opensearch.
@@ -48,11 +49,14 @@ If any side, Provider or Requirer doesn't support Juju Secrets, sensitive inform
   - Indices are not created on the provider application when the relation is created. The `index` field exists to grant the correct permissions for the relation user, which the requirer charm uses to control its index.
   - This index is NOT removed from the provider charm when the relation is removed.
 - Is expected to have different relations with the same interface name if Requirer needs access to multiple opensearch indices.
-- Is expected to provide user permissions in the `extra-user-roles` field. These permissions will be applied to the user created for the relation.
+- Can optionally provide user roles in the `extra-user-roles` field. These roles will be applied to the requested user or relation user.
   - This value can be empty, in which case a default will be applied, or it can be set to `admin`:
     - default: this has read-write permissions over the index that has been generated for this relation.
     - admin: this has control over the cluster, including creating new indices and setting cluster node roles.
-  - Specifics of how these permissions are implemented have been left to the provider charm developers, since they vary slightly between opensearch API-compliant applications.
+  - Specifics of how these roles are implemented have been left to the provider charm developers, since they vary slightly between opensearch API-compliant applications.
+- Can optionally provide group roles in the `extra-group-roles` field. These roles will be applied to the requested group.
+- Can optionally provide the `entity-type` field specifying the type of entity to request, instead of an index.
+- Can optionally provide the `entity-permissions` field specifying the permissions for the requested entity.
 - Is expected to tolerate that the Provider may ignore the `index` field in some cases and instead use the index name received.
 
 ## Relation Data

--- a/interfaces/opensearch_client/v0/schemas/provider.json
+++ b/interfaces/opensearch_client/v0/schemas/provider.json
@@ -62,6 +62,26 @@
             "examples": [
                 "8.0.27-18"
             ]
+        },
+        "entity-name": {
+            "$id": "#/properties/username",
+            "title": "Entity name",
+            "description": "Name for the requested custom entity.",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "custom-role"
+            ]
+        },
+        "entity-password": {
+            "$id": "#/properties/password",
+            "title": "Entity password",
+            "description": "Password for the requested custom entity.",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "alphanum-32byte-random"
+            ]
         }
     },
     "examples": [{

--- a/interfaces/opensearch_client/v0/schemas/requirer.json
+++ b/interfaces/opensearch_client/v0/schemas/requirer.json
@@ -35,6 +35,34 @@
             "examples": [
                 "default,admin"
             ]
+        },
+        "extra-group-roles": {
+            "title": "Extra-group-roles",
+            "description": "Any extra group roles requested by the requirer",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "charmed_read,charmed_dml"
+            ]
+        },
+        "entity-type": {
+            "title": "Entity-type",
+            "description": "Type of the requested entity (user / group)",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "USER",
+                "GROUP"
+            ]
+        },
+        "entity-permissions": {
+            "title": "Entity-permissions",
+            "description": "List of permissions to assigned to the custom entity, in JSON format",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "[{\"resource_name\": \"myindex\", \"resource_type\": \"INDEX\", \"privileges\": [\"WRITE\"]}]"
+            ]
         }
     },
     "examples": [{

--- a/interfaces/postgresql_client/v0/README.md
+++ b/interfaces/postgresql_client/v0/README.md
@@ -28,7 +28,8 @@ If any side, Provider or Requirer doesn't support Juju Secrets, sensitive inform
 
 ### Provider
 - Is expected to create an application user inside the database cluster when the requirer provides the `database` field.
-- Is expected to provide credentials (`username` and `password`) in a Juju Secret whenever the Requirer supplies the `database` field.
+- Is expected to provide relation user credentials (`username` and `password`) in a Juju Secret whenever the Requirer supplies the `database` field, but not the `entity-type` one.
+- Is expected to provide custom entity credentials (`entity-name` and `entity-password`) in a Juju Secret whenever the Requirer supplies both the `database` and `entity-type` fields.
 - Is expected to expose the Juju Secrets URI to the credentials through the `secret-user` field of the data bag.
 - Is expected to provide the `endpoints` field with the address of Primary, which can be used for Read/Write queries.
 - Is expected to provide the `database` field with the database that was actually created.
@@ -50,7 +51,10 @@ If any side, Provider or Requirer doesn't support Juju Secrets, sensitive inform
 - Is expected to have unique credentials for each relation. Therefore, different instances of the same Charm (juju applications) will have different relations with different credentials.
 - Is expected to have different relations names on Requirer with the same interface name if Requirer needs access to multiple database charms.
 - Is expected to allow multiple different Juju applications to access the same database name.
-- Is expected to add any `extra-user-roles` provided by the Requirer to the created user (e.g. `extra-user-roles=admin`).
+- Can optionally add any `extra-user-roles` provided by the Requirer to the requested user or relation user (e.g. `extra-user-roles=admin`).
+- Can optionally add any `extra-group-roles` provided by the Requirer to the requested group (e.g. `extra-group-roles=admin`).
+- Can optionally add field `entity-type` provided by the Requirer to the created a custom entity, instead of a database.
+- Can optionally add field `entity-permissions` provided by the Requirer to tweak custom entity permissions.
 - Is expected to tolerate that the Provider may ignore the `database` field in some cases and instead use the database name received.
 - Is expected to respect the `subordinated` flag when scaling up and start emitting events only once unit level `state` is `ready`.
 - May require external connectivity (via `external-node-connectivity`).

--- a/interfaces/postgresql_client/v0/schemas/provider.json
+++ b/interfaces/postgresql_client/v0/schemas/provider.json
@@ -133,6 +133,26 @@
             "examples": [
                 "-----BEGIN CERTIFICATE-----\nabcdexample\n-----END CERTIFICATE-----"
             ]
+        },
+        "entity-name": {
+            "$id": "#/properties/username",
+            "title": "Entity name",
+            "description": "Name for the requested custom entity.",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "custom-role"
+            ]
+        },
+        "entity-password": {
+            "$id": "#/properties/password",
+            "title": "Entity password",
+            "description": "Password for the requested custom entity.",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "alphanum-32byte-random"
+            ]
         }
     },
     "examples": [{

--- a/interfaces/postgresql_client/v0/schemas/requirer.json
+++ b/interfaces/postgresql_client/v0/schemas/requirer.json
@@ -27,6 +27,15 @@
                 "type": "string"
             }
         },
+        "external-node-connectivity": {
+            "title": "External node connectivity",
+            "description": "Provide external connectivity, if subordinate router",
+            "type": "string",
+            "default": "true",
+            "examples": [
+                "true"
+            ]
+        },
         "extra-user-roles": {
             "title": "Extra-user-roles",
             "description": "Any extra user roles requested by the requirer",
@@ -36,13 +45,32 @@
                 "default,admin"
             ]
         },
-        "external-node-connectivity": {
-            "title": "External node connectivity",
-            "description": "Provide external connectivity, if subordinate router",
+        "extra-group-roles": {
+            "title": "Extra-group-roles",
+            "description": "Any extra group roles requested by the requirer",
             "type": "string",
-            "default": "true",
+            "default": "",
             "examples": [
-                "true"
+                "charmed_read,charmed_dml"
+            ]
+        },
+        "entity-type": {
+            "title": "Entity-type",
+            "description": "Type of the requested entity (user / group)",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "USER",
+                "GROUP"
+            ]
+        },
+        "entity-permissions": {
+            "title": "Entity-permissions",
+            "description": "List of permissions to assigned to the custom entity, in JSON format",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "[{\"resource_name\": \"items\", \"resource_type\": \"TABLE\", \"privileges\": [\"SELECT\"]}]"
             ]
         }
     },


### PR DESCRIPTION
This PR updates the definition of every Data Platform product affected by the upcoming work of _custom-roles_ and _custom-role permissions_ in version 0 of the data-interfaces charm lib.

Depends on PRs:
- https://github.com/canonical/data-platform-libs/pull/218
- https://github.com/canonical/data-platform-libs/pull/227