### PR TITLE
ci: make uv and poetry available in matrix test environment

### DIFF
--- a/.github/workflows/matrix-tests.yaml
+++ b/.github/workflows/matrix-tests.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies
-        run: pip install tox
+        run: pip install tox uv poetry
       - name: Run tests
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_WITH_TEAM }}


### PR DESCRIPTION
Charms that use `poetry` or `uv` may want to use these tools in `pre_run` to (e.g.) generate a `requirements.txt` file. Will allow merging #269.