### PR TITLE
ci: let matrix tests run for a single interface from a PR branch

### DIFF
--- a/.github/workflows/dispatch-matrix-tests.yaml
+++ b/.github/workflows/dispatch-matrix-tests.yaml
@@ -1,0 +1,55 @@
+name: Matrix tests for a specific interface
+
+on:
+  workflow_dispatch:
+    inputs:
+      interface:
+        description: 'The interface to run tests for'
+        required: true
+        type: string
+      repo:
+        description: 'The repo to fetch the test and interfaces definitions from'
+        default: 'https://github.com/canonical/charm-relation-interfaces'
+        required: false
+        type: string
+      branch:
+        description: 'The branch of the repo to fetch the test and interface definitions from'
+        default: 'main'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      interface:
+        description: 'The interface to run tests for'
+        required: true
+        type: string
+      repo:
+        description: 'The repo to fetch the test and interfaces definitions from'
+        default: 'https://github.com/canonical/charm-relation-interfaces'
+        required: false
+        type: string
+      branch:
+        description: 'The branch of the repo to fetch the test and interface definitions from'
+        default: 'main'
+        required: false
+        type: string
+
+jobs:
+  matrix-tests:
+    name: 'Matrix tests for ${{ inputs.interface }}'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Set up python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: pip install tox uv poetry
+      - name: Run tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_WITH_TEAM }}
+        run: tox -e run-interface-test-matrix -- --include ${{ inputs.interface }} --repo ${{ inputs.repo }} --branch ${{ inputs.branch }}

--- a/.github/workflows/matrix-tests.yaml
+++ b/.github/workflows/matrix-tests.yaml
@@ -24,23 +24,10 @@ jobs:
   main:
     name: ${{ matrix.interface }}
     needs: set-matrix
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         interface: ${{ fromJSON(needs.set-matrix.outputs.matrix_values) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-      - name: Set up python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.8
-      - name: Install dependencies
-        run: pip install tox uv poetry
-      - name: Run tests
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_WITH_TEAM }}
-        run: tox -e run-interface-test-matrix -- --include ${{ matrix.interface }}
+    uses: ./.github/workflows/dispatch-matrix-tests.yaml
+    with:
+      interface: ${{ matrix.interface }}


### PR DESCRIPTION
This PR moves the logic to invoke the matrix tests for an individual interface to a reusable workflow, and allows specifying the repository and branch to fetch the test and interface definitions from. This will allow the tests added by a PR to be (manually) run in the CI context before merging, instead of only being able to test them locally.

Here is [a manual run of the matrix tests workflow from my fork](https://github.com/james-garner-canonical/charm-relation-interfaces/actions/runs/16741618134), and here is [the most recent run of the same workflow on main](https://github.com/canonical/charm-relation-interfaces/actions/runs/16711095816). The same interfaces are passing and failing in both cases.