### PR TITLE
docs: replace ops.testing link by how-to link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ For the time being, to see available interfaces, their statuses, and schemas, br
 
 # Relation interface testers
 
-In order to automatically validate whether a charm satisfies a given relation interface, the relation interface maintainer(s) need to write one or more **relation interface tests**. A relation interface test is a [scenario-based test case](https://ops.readthedocs.io/en/latest/reference/ops-testing.html) which checks that, given an initial context, when a relation event is triggered, the charm will do what the interface specifies. For example, most interface testers will check that, on relation changed, the charm will write a certain value into its (app/unit) databag and that that value matches a certain (Pydantic) schema.
+In order to automatically validate whether a charm satisfies a given relation interface, the relation interface maintainer(s) need to write one or more **relation interface tests**. A relation interface test is a [scenario-based test case](https://documentation.ubuntu.com/ops/latest/howto/manage-interfaces/#write-tests-for-an-interface) which checks that, given an initial context, when a relation event is triggered, the charm will do what the interface specifies. For example, most interface testers will check that, on relation changed, the charm will write a certain value into its (app/unit) databag and that that value matches a certain (Pydantic) schema.
 
 See [the tester documentation](https://github.com/canonical/interface-tester-pytest) for more.


### PR DESCRIPTION
I was initially only going to update the Ops link in the README to point to documentation.ubuntu.com instead. Then it occurred to me that it might be more useful to link to our how-to doc about interface tests, instead of the reference docs for Scenario.