### PR TITLE
ci: bump matrix tests Python version 3.8 -> 3.10

### DIFF
--- a/.github/workflows/dispatch-matrix-tests.yaml
+++ b/.github/workflows/dispatch-matrix-tests.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: '3.10'
       - name: Install dependencies
         run: pip install tox uv poetry
       - name: Run tests


### PR DESCRIPTION
`run_matrix.py` uses Python 3.9+ features (`pathlib.PurePath.is_relative_to`). That code only triggers if `charm_root` is set, but I'm still surprised that this hasn't been an issue yet. It was noticed in #295. Are there any concerns with bumping the Python version? I've verified [here](https://github.com/canonical/charm-relation-interfaces/actions/runs/17285932508/job/49063088437?pr=297) that the matrix tests all pass with this change.