### PR TITLE
ci: bump Python version to 3.12 since some tests require this

### DIFF
--- a/.github/workflows/dispatch-matrix-tests.yaml
+++ b/.github/workflows/dispatch-matrix-tests.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Install dependencies
         run: pip install tox uv poetry
       - name: Run tests


### PR DESCRIPTION
This PR bumps the Python version for matrix tests all the way to 3.12 since the `litmus_auth` tests won't pass without this (#295), and all the other tests seem to be in a shambles anyway.