### PR TITLE
ci: install poetry-plugin-export for poetry export

### DIFF
--- a/.github/workflows/dispatch-matrix-tests.yaml
+++ b/.github/workflows/dispatch-matrix-tests.yaml
@@ -48,7 +48,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install dependencies
-        run: pip install tox uv poetry
+        run: pip install tox uv poetry poetry-plugin-export
       - name: Run tests
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_WITH_TEAM }}


### PR DESCRIPTION
We recently recommended using `poetry export ...` in `pre_run` to get Poetry style deps into `requirements.txt` format for the interface tests, but the `poetry-plugin-export` Poetry plugin is required to provide the `export` subcommand. This PR installs the plugin at the same time as we install `poetry` for interface tests.